### PR TITLE
USER removed in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -a -installsuffix cgo -o 
 # https://github.com/GoogleContainerTools/kaniko/issues/477
 
 
-FROM alpine:3.7
+FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/local/bin/radix-api /usr/local/bin/radix-api
-RUN adduser -D -g '' radix-api
-RUN ls /etc/passwd
-USER radix-api
 EXPOSE 3001
 ENTRYPOINT ["/usr/local/bin/radix-api"]


### PR DESCRIPTION
probably best practise to set which user to run under, however this is already decided in cluster through deployment object. the USER introduced issue in kaniko