### PR TITLE
User should be able to see env if build fails

### DIFF
--- a/api/environments/environment_handler.go
+++ b/api/environments/environment_handler.go
@@ -107,17 +107,11 @@ func (eh EnvironmentHandler) GetEnvironment(appName, envName string) (*environme
 		return nil, err
 	}
 
-	secrets, err := eh.GetEnvironmentSecrets(appName, envName)
-	if err != nil {
-		return nil, err
-	}
-
 	environment := &environmentModels.Environment{
 		Name:          envName,
 		BranchMapping: buildFrom,
 		Status:        configurationStatus.String(),
 		Deployments:   deployments,
-		Secrets:       secrets,
 	}
 
 	if len(deployments) > 0 {
@@ -127,6 +121,13 @@ func (eh EnvironmentHandler) GetEnvironment(appName, envName string) (*environme
 		}
 
 		environment.ActiveDeployment = deployment
+
+		secrets, err := eh.GetEnvironmentSecrets(appName, envName)
+		if err != nil {
+			return nil, err
+		}
+
+		environment.Secrets = secrets
 	}
 
 	return environment, nil


### PR DESCRIPTION
When there is no deployment is there, it should not try to access a secret haven't been defined. Secrets are defined when RD is applied to the namespace