### PR TITLE
RA-641: improve performance -  do not get env per job

### DIFF
--- a/api/applications/applications_controller.go
+++ b/api/applications/applications_controller.go
@@ -154,8 +154,9 @@ func GetApplicationStream(clients models.Clients, resource string, resourceIdent
 // ShowApplications Lists applications
 func (ac *applicationController) ShowApplications(clients models.Clients, w http.ResponseWriter, r *http.Request) {
 	// swagger:operation GET /applications platform showApplications
+	//
 	// ---
-	// summary: Lists the applications
+	// summary: Lists the applications. NOTE - doesn't get applicationSummary.latestJob.Environments
 	// parameters:
 	// - name: sshRepo
 	//   in: query

--- a/api/applications/get_applications_handler.go
+++ b/api/applications/get_applications_handler.go
@@ -17,7 +17,7 @@ import (
 
 type hasAccessToRR func(client kubernetes.Interface, rr v1.RadixRegistration) bool
 
-// GetApplications handler for ShowApplications
+// GetApplications handler for ShowApplications - NOTE: does not get latestJob.Environments
 func (ah ApplicationHandler) GetApplications(sshRepo string, hasAccess hasAccessToRR) ([]*applicationModels.ApplicationSummary, error) {
 	radixRegistationList, err := ah.serviceAccount.RadixClient.RadixV1().RadixRegistrations().List(metav1.ListOptions{})
 	if err != nil {

--- a/api/jobs/get_job_handler.go
+++ b/api/jobs/get_job_handler.go
@@ -59,7 +59,7 @@ func Init(
 	}
 }
 
-// GetLatestJobPerApplication Handler for GetApplicationJobs
+// GetLatestJobPerApplication Handler for GetApplicationJobs - NOTE: does not get latestJob.Environments
 func (jh JobHandler) GetLatestJobPerApplication(forApplications map[string]bool) (map[string]*jobModels.JobSummary, error) {
 	jobList, err := jh.getAllJobs()
 	if err != nil {
@@ -86,12 +86,7 @@ func (jh JobHandler) GetLatestJobPerApplication(forApplications map[string]bool)
 			continue
 		}
 
-		jobEnvironmentsMap, err := jh.getJobEnvironmentMap(appName)
-		if err != nil {
-			return nil, err
-		}
-
-		jobSummary, err := jh.getJobSummaryWithDeployment(appName, &job, jobEnvironmentsMap)
+		jobSummary, err := jh.getJobSummaryWithDeployment(appName, &job, map[string][]string{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
GetApplication now does not return env for jobs. Have confirmed this is not needed in client. We do not change model, as it is also used by getJobsByApp, where the env for jobs is required