### PR TITLE
Merge radixjobs from master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -105,7 +105,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:786cee5bc98432b16a43eed09ca83896f5fa720b65bf351781a92d366e2b790f"
+  digest = "1:3da17d8d4190a276c57955b8f1fcf5e50ceef733efab6f1e120fdb238959861e"
   name = "github.com/equinor/radix-operator"
   packages = [
     "pkg/apis/application",
@@ -134,7 +134,7 @@
     "pkg/client/listers/radix/v1",
   ]
   pruneopts = ""
-  revision = "816150c073ca2b8da65fdf847f643f2b485355d8"
+  revision = "f8e5fead1619e3aed1891896fc9cc9089c28639b"
 
 [[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"

--- a/api/applications/applications_controller_test.go
+++ b/api/applications/applications_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/application"
 	"github.com/equinor/radix-operator/pkg/apis/applicationconfig"
 	"github.com/equinor/radix-operator/pkg/apis/deployment"
+	jobPipeline "github.com/equinor/radix-operator/pkg/apis/pipeline"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 
 	applicationModels "github.com/equinor/radix-api/api/applications/models"
@@ -19,7 +20,6 @@ import (
 	controllertest "github.com/equinor/radix-api/api/test"
 	"github.com/equinor/radix-api/api/utils"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
-	jobPipeline "github.com/equinor/radix-operator/pkg/apis/pipeline"
 	commontest "github.com/equinor/radix-operator/pkg/apis/test"
 	builders "github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/client/clientset/versioned/fake"
@@ -90,7 +90,6 @@ func TestGetApplications_HasAccessToSomeRR(t *testing.T) {
 		applications := make([]applicationModels.ApplicationSummary, 0)
 		controllertest.GetResponseBody(response, &applications)
 		assert.Equal(t, 1, len(applications))
-		// assert.Equal(t, "my-second-app", applications[0].Name)
 	})
 
 	t.Run("access to all app", func(t *testing.T) {
@@ -588,7 +587,7 @@ func TestHandleTriggerPipeline_ForNonMappedAndMappedAndMagicBranchEnvironment_Jo
 	unmappedBranch := "feature"
 
 	parameters := applicationModels.PipelineParametersBuild{Branch: unmappedBranch}
-	responseChannel := controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", anyAppName, jobPipeline.BuildDeploy), parameters)
+	responseChannel := controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", anyAppName, v1.BuildDeploy), parameters)
 	response := <-responseChannel
 
 	assert.Equal(t, http.StatusBadRequest, response.Code)
@@ -598,14 +597,14 @@ func TestHandleTriggerPipeline_ForNonMappedAndMappedAndMagicBranchEnvironment_Jo
 
 	// Mapped branch should start job
 	parameters = applicationModels.PipelineParametersBuild{Branch: "dev"}
-	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", anyAppName, jobPipeline.BuildDeploy), parameters)
+	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", anyAppName, v1.BuildDeploy), parameters)
 	response = <-responseChannel
 
 	assert.Equal(t, http.StatusOK, response.Code)
 
 	// Magic branch should start job, even if it is not mapped
 	parameters = applicationModels.PipelineParametersBuild{Branch: applicationconfig.MagicBranch}
-	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", anyAppName, jobPipeline.BuildDeploy), parameters)
+	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", anyAppName, v1.BuildDeploy), parameters)
 	response = <-responseChannel
 
 	assert.Equal(t, http.StatusOK, response.Code)
@@ -622,7 +621,7 @@ func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedFor
 	const pushCommitID = "4faca8595c5283a9d0f17a623b9255a0d9866a2e"
 
 	parameters := applicationModels.PipelineParametersBuild{Branch: "master", CommitID: pushCommitID}
-	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", "another-app", jobPipeline.BuildDeploy), parameters)
+	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", "another-app", v1.BuildDeploy), parameters)
 	response := <-responseChannel
 
 	assert.Equal(t, http.StatusNotFound, response.Code)
@@ -630,7 +629,7 @@ func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedFor
 	assert.Equal(t, controllertest.AppNotFoundErrorMsg("another-app"), errorResponse.Message)
 
 	parameters = applicationModels.PipelineParametersBuild{Branch: "", CommitID: pushCommitID}
-	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", "any-app", jobPipeline.BuildDeploy), parameters)
+	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", "any-app", v1.BuildDeploy), parameters)
 	response = <-responseChannel
 
 	assert.Equal(t, http.StatusBadRequest, response.Code)
@@ -639,7 +638,7 @@ func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedFor
 	assert.Equal(t, (expectedError.(*utils.Error)).Message, errorResponse.Message)
 
 	parameters = applicationModels.PipelineParametersBuild{Branch: "master", CommitID: pushCommitID}
-	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", "any-app", jobPipeline.BuildDeploy), parameters)
+	responseChannel = controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", "any-app", v1.BuildDeploy), parameters)
 	response = <-responseChannel
 	assert.Equal(t, http.StatusOK, response.Code)
 
@@ -651,7 +650,7 @@ func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedFor
 }
 
 func TestHandleTriggerPipeline_Promote_JobHasCorrectParameters(t *testing.T) {
-	_, controllerTestUtils, kubeclient, _ := setupTest()
+	_, controllerTestUtils, _, radixclient := setupTest()
 
 	appName := "an-app"
 
@@ -662,16 +661,15 @@ func TestHandleTriggerPipeline_Promote_JobHasCorrectParameters(t *testing.T) {
 	}
 
 	<-controllerTestUtils.ExecuteRequestWithParameters("POST", "/api/v1/applications", AnApplicationRegistration().withName(appName).Build())
-	responseChannel := controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", appName, jobPipeline.Promote), parameters)
+	responseChannel := controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/pipelines/%s", appName, v1.Promote), parameters)
 	<-responseChannel
 
 	appNamespace := fmt.Sprintf("%s-app", appName)
-	jobs, _ := getJobsInNamespace(kubeclient, appNamespace)
-	jobArgs := jobs[0].Spec.Template.Spec.Containers[0].Args
+	jobs, _ := getJobsInNamespace(radixclient, appNamespace)
 
-	assert.Equal(t, true, contains(jobArgs, "FROM_ENVIRONMENT=origin"))
-	assert.Equal(t, true, contains(jobArgs, "TO_ENVIRONMENT=target"))
-	assert.Equal(t, true, contains(jobArgs, "DEPLOYMENT_NAME=a-deployment"))
+	assert.Equal(t, jobs[0].Spec.Promote.FromEnvironment, "origin")
+	assert.Equal(t, jobs[0].Spec.Promote.ToEnvironment, "target")
+	assert.Equal(t, jobs[0].Spec.Promote.DeploymentName, "a-deployment")
 }
 
 func TestIsDeployKeyValid(t *testing.T) {
@@ -865,19 +863,10 @@ func createRadixJob(kubeclient *kubefake.Clientset, appName, jobName string, sta
 			}})
 }
 
-func getJobsInNamespace(kubeclient *kubefake.Clientset, appNamespace string) ([]batchv1.Job, error) {
-	jobs, err := kubeclient.BatchV1().Jobs(appNamespace).List(metav1.ListOptions{})
+func getJobsInNamespace(radixclient *fake.Clientset, appNamespace string) ([]v1.RadixJob, error) {
+	jobs, err := radixclient.RadixV1().RadixJobs(appNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return jobs.Items, nil
-}
-
-func contains(stack []string, needle string) bool {
-	for _, item := range stack {
-		if item == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/api/applications/applications_handler.go
+++ b/api/applications/applications_handler.go
@@ -224,7 +224,7 @@ func (ah ApplicationHandler) GetSupportedPipelines() []string {
 	supportedPipelines := make([]string, 0)
 	pipelines := jobPipeline.GetSupportedPipelines()
 	for _, pipeline := range pipelines {
-		supportedPipelines = append(supportedPipelines, pipeline.Name)
+		supportedPipelines = append(supportedPipelines, string(pipeline.Type))
 	}
 
 	return supportedPipelines
@@ -236,13 +236,13 @@ func (ah ApplicationHandler) TriggerPipeline(appName, pipelineName string, r *ht
 	var err error
 
 	switch pipelineName {
-	case jobPipeline.Build, jobPipeline.BuildDeploy:
+	case string(v1.Build), string(v1.BuildDeploy):
 		var pipelineParameters applicationModels.PipelineParametersBuild
 		if err = json.NewDecoder(r.Body).Decode(&pipelineParameters); err != nil {
 			return nil, err
 		}
 		jobSummary, err = ah.TriggerPipelineBuild(appName, pipelineName, pipelineParameters)
-	case jobPipeline.Promote:
+	case string(v1.Promote):
 		var pipelineParameters applicationModels.PipelineParametersPromote
 		if err = json.NewDecoder(r.Body).Decode(&pipelineParameters); err != nil {
 			return nil, err

--- a/api/jobs/get_job_handler.go
+++ b/api/jobs/get_job_handler.go
@@ -5,12 +5,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"fmt"
 	"strings"
 
 	deployments "github.com/equinor/radix-api/api/deployments"
@@ -18,10 +16,7 @@ import (
 	jobModels "github.com/equinor/radix-api/api/jobs/models"
 	"github.com/equinor/radix-api/api/utils"
 	"github.com/equinor/radix-api/models"
-	"github.com/equinor/radix-operator/pkg/apis/kube"
-	pipelineJob "github.com/equinor/radix-operator/pkg/apis/pipeline"
 	crdUtils "github.com/equinor/radix-operator/pkg/apis/utils"
-	"github.com/equinor/radix-operator/pkg/apis/utils/git"
 	radixclient "github.com/equinor/radix-operator/pkg/client/clientset/versioned"
 )
 
@@ -61,40 +56,7 @@ func Init(
 
 // GetLatestJobPerApplication Handler for GetApplicationJobs - NOTE: does not get latestJob.Environments
 func (jh JobHandler) GetLatestJobPerApplication(forApplications map[string]bool) (map[string]*jobModels.JobSummary, error) {
-	jobList, err := jh.getAllJobs()
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Slice(jobList.Items, func(i, j int) bool {
-		switch strings.Compare(jobList.Items[i].Labels[kube.RadixAppLabel], jobList.Items[j].Labels[kube.RadixAppLabel]) {
-		case -1:
-			return true
-		case 1:
-			return false
-		}
-		return jobList.Items[j].Status.StartTime.Before(jobList.Items[i].Status.StartTime)
-	})
-
-	applicationJob := make(map[string]*jobModels.JobSummary)
-	for _, job := range jobList.Items {
-		appName := job.Labels[kube.RadixAppLabel]
-		if applicationJob[appName] != nil {
-			continue
-		}
-		if forApplications[appName] != true {
-			continue
-		}
-
-		jobSummary, err := jh.getJobSummaryWithDeployment(appName, &job, map[string][]string{})
-		if err != nil {
-			return nil, err
-		}
-
-		applicationJob[appName] = jobSummary
-	}
-
-	return applicationJob, nil
+	return jh.getLatestJobPerApplication(forApplications)
 }
 
 // GetApplicationJobs Handler for GetApplicationJobs
@@ -116,50 +78,13 @@ func (jh JobHandler) GetLatestApplicationJob(appName string) (*jobModels.JobSumm
 	return jobs[0], nil
 }
 
-func (jh JobHandler) getApplicationJobs(appName string) ([]*jobModels.JobSummary, error) {
-	jobList, err := jh.getJobs(appName)
-	if err != nil {
-		return nil, err
-	}
-
-	// Sort jobs descending
-	sort.Slice(jobList.Items, func(i, j int) bool {
-		return jobList.Items[j].Status.StartTime.Before(jobList.Items[i].Status.StartTime)
-	})
-
-	jobEnvironmentsMap, err := jh.getJobEnvironmentMap(appName)
-	if err != nil {
-		return nil, err
-	}
-
-	jobs := make([]*jobModels.JobSummary, len(jobList.Items))
-	for i, job := range jobList.Items {
-		jobSummary, err := jh.getJobSummaryWithDeployment(appName, &job, jobEnvironmentsMap)
-		if err != nil {
-			return nil, err
-		}
-
-		jobs[i] = jobSummary
-	}
-
-	return jobs, nil
-}
-
 // GetApplicationJob Handler for GetApplicationJob
 func (jh JobHandler) GetApplicationJob(appName, jobName string) (*jobModels.Job, error) {
-	job, err := jh.userAccount.Client.BatchV1().Jobs(crdUtils.GetAppNamespace(appName)).Get(jobName, metav1.GetOptions{})
+	job, err := jh.userAccount.RadixClient.RadixV1().RadixJobs(crdUtils.GetAppNamespace(appName)).Get(jobName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		return nil, jobModels.PipelineNotFoundError(appName, jobName)
+		// This may be a job triggered before the introduction of a RadixJob
+		return jh.getApplicationJobLegacy(appName, jobName)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	if !strings.EqualFold(job.Labels[kube.RadixJobTypeLabel], RadixJobTypeJob) {
-		return nil, utils.ValidationError("Radix Application Job", "Job was not of expected type")
-	}
-
-	steps, err := jh.getJobSteps(appName, job)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +99,136 @@ func (jh JobHandler) GetApplicationJob(appName, jobName string) (*jobModels.Job,
 		return nil, err
 	}
 
-	return jobModels.GetJob(job, steps, jobDeployments, jobComponents), nil
+	return jobModels.GetJobFromRadixJob(job, jobDeployments, jobComponents), nil
+}
+
+func (jh JobHandler) getApplicationJobs(appName string) ([]*jobModels.JobSummary, error) {
+	jobs, err := jh.getJobs(appName)
+	if err != nil {
+		return nil, err
+	}
+
+	legacyJobs, err := jh.getApplicationJobsLegacy(appName)
+	if err == nil && len(legacyJobs) > 0 {
+		// Append legacy jobs to list which is not contained in list of jobs
+		for _, legacyJob := range legacyJobs {
+			exists := false
+
+			for _, job := range jobs {
+				if legacyJob.Name == job.Name {
+					exists = true
+					break
+				}
+			}
+
+			if !exists {
+				jobs = append(jobs, legacyJob)
+			}
+		}
+	}
+
+	// Sort jobs descending
+	sort.Slice(jobs, func(i, j int) bool {
+		jCreatedTimeStamp := jobs[j].Created
+		jCreated, err := utils.ParseTimestamp(jCreatedTimeStamp)
+		if err != nil {
+			return true
+		}
+
+		iCreatedTimestamp := jobs[i].Created
+		iCreated, err := utils.ParseTimestamp(iCreatedTimestamp)
+		if err != nil {
+			return false
+		}
+
+		return jCreated.Before(iCreated)
+	})
+
+	return jobs, nil
+}
+
+func (jh JobHandler) getAllJobs() ([]*jobModels.JobSummary, error) {
+	return jh.getJobsInNamespace(jh.serviceAccount.RadixClient, corev1.NamespaceAll)
+}
+
+func (jh JobHandler) getJobs(appName string) ([]*jobModels.JobSummary, error) {
+	return jh.getJobsInNamespace(jh.userAccount.RadixClient, crdUtils.GetAppNamespace(appName))
+}
+
+func (jh JobHandler) getJobsInNamespace(radixClient radixclient.Interface, namespace string) ([]*jobModels.JobSummary, error) {
+	jobList, err := jh.userAccount.RadixClient.RadixV1().RadixJobs(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]*jobModels.JobSummary, len(jobList.Items))
+	for i, job := range jobList.Items {
+		jobs[i] = jobModels.GetSummaryFromRadixJob(&job)
+	}
+
+	return jobs, nil
+}
+
+func (jh JobHandler) getLatestJobPerApplication(forApplications map[string]bool) (map[string]*jobModels.JobSummary, error) {
+	// Primarily use Radix Jobs
+	allJobs, err := jh.getAllJobs()
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(allJobs, func(i, j int) bool {
+		switch strings.Compare(allJobs[i].AppName, allJobs[j].AppName) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+
+		jCreated, err := utils.ParseTimestamp(allJobs[j].Created)
+		if err != nil {
+			return true
+		}
+
+		iCreated, err := utils.ParseTimestamp(allJobs[i].Created)
+		if err != nil {
+			return false
+		}
+
+		return jCreated.Before(iCreated)
+	})
+
+	applicationJob := make(map[string]*jobModels.JobSummary)
+	for _, job := range allJobs {
+		if applicationJob[job.AppName] != nil {
+			continue
+		}
+		if forApplications[job.AppName] != true {
+			continue
+		}
+
+		if job.Started == "" {
+			// Job may still be queued or waiting to be scheduled by the operator
+			continue
+		}
+
+		applicationJob[job.AppName] = job
+	}
+
+	forApplicationsWithNoRadixJob := make(map[string]bool)
+	for applicationName := range forApplications {
+		if applicationJob[applicationName] == nil {
+			forApplicationsWithNoRadixJob[applicationName] = true
+		}
+	}
+
+	if len(forApplicationsWithNoRadixJob) > 0 {
+		applicationJobForApplicationsWithNoRadixJob, _ := jh.getLatestJobPerApplicationLegacy(forApplicationsWithNoRadixJob)
+		for applicationName, job := range applicationJobForApplicationsWithNoRadixJob {
+			applicationJob[applicationName] = job
+		}
+	}
+
+	return applicationJob, nil
 }
 
 func (jh JobHandler) getJobComponents(appName string, jobName string) ([]*deploymentModels.ComponentSummary, error) {
@@ -203,230 +257,4 @@ func (jh JobHandler) getJobComponents(appName string, jobName string) ([]*deploy
 	}
 
 	return jobComponents, nil
-}
-
-func (jh JobHandler) getJobSteps(appName string, job *batchv1.Job) ([]jobModels.Step, error) {
-	steps := []jobModels.Step{}
-	jobName := job.GetName()
-
-	pipelinePod, err := jh.getPipelinePod(appName, jobName)
-	if err != nil {
-		return nil, err
-	} else if pipelinePod == nil {
-		return steps, nil
-	}
-
-	if len(pipelinePod.Status.ContainerStatuses) == 0 {
-		return steps, nil
-	}
-
-	pipelineType := job.Labels["radix-pipeline"]
-
-	switch pipelineType {
-	case pipelineJob.Build, pipelineJob.BuildDeploy:
-		return jh.getJobStepsBuildPipeline(appName, pipelinePod, job)
-	case pipelineJob.Promote:
-		return jh.getJobStepsPromotePipeline(appName, pipelinePod, job)
-	}
-
-	return steps, nil
-}
-
-func (jh JobHandler) getJobStepsBuildPipeline(appName string, pipelinePod *corev1.Pod, job *batchv1.Job) ([]jobModels.Step, error) {
-	steps := []jobModels.Step{}
-	if len(pipelinePod.Status.InitContainerStatuses) == 0 {
-		return steps, nil
-	}
-
-	pipelineJobStep := getPipelineJobStep(pipelinePod)
-	cloneContainerStatus := getCloneContainerStatus(pipelinePod)
-	if cloneContainerStatus == nil {
-		return steps, nil
-	}
-
-	// Clone of radix config should be represented
-	pipelineCloneStep := getJobStep(pipelinePod.GetName(), cloneContainerStatus)
-	pipelineCloneStep.Name = "clone-config"
-
-	jobStepsLabelSelector := fmt.Sprintf("%s=%s, %s!=%s", kube.RadixImageTagLabel, job.Labels[kube.RadixImageTagLabel], kube.RadixJobTypeLabel, RadixJobTypeJob)
-
-	jobStepList, err := jh.userAccount.Client.BatchV1().Jobs(crdUtils.GetAppNamespace(appName)).List(metav1.ListOptions{
-		LabelSelector: jobStepsLabelSelector,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	// pipeline coordinator
-	steps = append(steps, pipelineCloneStep, pipelineJobStep)
-	for _, jobStep := range jobStepList.Items {
-		jobStepPod, err := jh.userAccount.Client.CoreV1().Pods(crdUtils.GetAppNamespace(appName)).List(metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", "job-name", jobStep.Name),
-		})
-
-		if err != nil {
-			return nil, err
-		}
-
-		if len(jobStepPod.Items) == 0 {
-			continue
-		}
-
-		pod := jobStepPod.Items[0]
-		for _, containerStatus := range pod.Status.InitContainerStatuses {
-			if strings.HasPrefix(containerStatus.Name, git.InternalContainerPrefix) {
-				continue
-			}
-
-			steps = append(steps, getJobStep(pod.GetName(), &containerStatus))
-		}
-
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			steps = append(steps, getJobStep(pod.GetName(), &containerStatus))
-		}
-	}
-
-	return steps, nil
-}
-
-func (jh JobHandler) getJobStepsPromotePipeline(appName string, pipelinePod *corev1.Pod, job *batchv1.Job) ([]jobModels.Step, error) {
-	steps := []jobModels.Step{}
-	pipelineJobStep := getJobStep(pipelinePod.GetName(), &pipelinePod.Status.ContainerStatuses[0])
-	steps = append(steps, pipelineJobStep)
-	return steps, nil
-}
-
-// GetJobSummaryWithDeployment Used to get job summary from a kubernetes job
-func (jh JobHandler) getJobSummaryWithDeployment(appName string, job *batchv1.Job, jobEnvironmentsMap map[string][]string) (*jobModels.JobSummary, error) {
-	jobSummary := jobModels.GetJobSummary(job)
-	jobSummary.Environments = jobEnvironmentsMap[job.Name]
-	return jobSummary, nil
-}
-
-func (jh JobHandler) getJobEnvironmentMap(appName string) (map[string][]string, error) {
-	allDeployments, err := jh.deploy.GetDeploymentsForApplication(appName, false)
-	if err != nil {
-		return nil, err
-	}
-
-	jobEnvironmentsMap := make(map[string][]string)
-	for _, deployment := range allDeployments {
-		if jobEnvironmentsMap[deployment.CreatedByJob] == nil {
-			environments := make([]string, 1)
-			environments[0] = deployment.Environment
-			jobEnvironmentsMap[deployment.CreatedByJob] = environments
-		} else {
-			environments := jobEnvironmentsMap[deployment.CreatedByJob]
-			environments = append(environments, deployment.Environment)
-			jobEnvironmentsMap[deployment.CreatedByJob] = environments
-		}
-	}
-
-	return jobEnvironmentsMap, nil
-}
-
-func (jh JobHandler) getPipelinePod(appName, jobName string) (*corev1.Pod, error) {
-	ns := crdUtils.GetAppNamespace(appName)
-	pods, err := jh.userAccount.Client.CoreV1().Pods(ns).List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", "job-name", jobName),
-	})
-
-	if err != nil {
-		return nil, err
-	}
-	if len(pods.Items) == 0 {
-		// pipeline pod not found
-		return nil, nil
-	}
-
-	return &pods.Items[0], nil
-}
-
-func (jh JobHandler) getAllJobs() (*batchv1.JobList, error) {
-	return jh.getJobsInNamespace(jh.serviceAccount.Client, corev1.NamespaceAll)
-}
-
-func (jh JobHandler) getJobs(appName string) (*batchv1.JobList, error) {
-	return jh.getJobsInNamespace(jh.userAccount.Client, crdUtils.GetAppNamespace(appName))
-}
-
-func (jh JobHandler) getJobsInNamespace(kubeClient kubernetes.Interface, namespace string) (*batchv1.JobList, error) {
-	jobList, err := kubeClient.BatchV1().Jobs(namespace).List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", kube.RadixJobTypeLabel, RadixJobTypeJob),
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return jobList, nil
-}
-
-func getPipelineJobStep(pipelinePod *corev1.Pod) jobModels.Step {
-	var pipelineJobStep jobModels.Step
-
-	cloneContainerStatus := getCloneContainerStatus(pipelinePod)
-	if cloneContainerStatus == nil {
-		return jobModels.Step{}
-	}
-
-	if cloneContainerStatus.State.Terminated != nil &&
-		cloneContainerStatus.State.Terminated.ExitCode > 0 {
-		pipelineJobStep = getJobStepWithContainerName(pipelinePod.GetName(),
-			pipelinePod.Status.ContainerStatuses[0].Name, cloneContainerStatus)
-	} else {
-		pipelineJobStep = getJobStep(pipelinePod.GetName(), &pipelinePod.Status.ContainerStatuses[0])
-	}
-
-	return pipelineJobStep
-}
-
-func getCloneContainerStatus(pipelinePod *corev1.Pod) *corev1.ContainerStatus {
-	for _, containerStatus := range pipelinePod.Status.InitContainerStatuses {
-		if containerStatus.Name == git.CloneContainerName {
-			return &containerStatus
-		}
-	}
-
-	return nil
-}
-
-func getJobStep(podName string, containerStatus *corev1.ContainerStatus) jobModels.Step {
-	return getJobStepWithContainerName(podName, containerStatus.Name, containerStatus)
-}
-
-func getJobStepWithContainerName(podName, containerName string, containerStatus *corev1.ContainerStatus) jobModels.Step {
-	var startedAt metav1.Time
-	var finishedAt metav1.Time
-
-	status := jobModels.Succeeded
-
-	if containerStatus == nil {
-		status = jobModels.Waiting
-
-	} else if containerStatus.State.Terminated != nil {
-		startedAt = containerStatus.State.Terminated.StartedAt
-		finishedAt = containerStatus.State.Terminated.FinishedAt
-
-		if containerStatus.State.Terminated.ExitCode > 0 {
-			status = jobModels.Failed
-		}
-
-	} else if containerStatus.State.Running != nil {
-		startedAt = containerStatus.State.Running.StartedAt
-		status = jobModels.Running
-
-	} else if containerStatus.State.Waiting != nil {
-		status = jobModels.Waiting
-
-	}
-
-	return jobModels.Step{
-		Name:    containerName,
-		Started: utils.FormatTime(&startedAt),
-		Ended:   utils.FormatTime(&finishedAt),
-		Status:  status.String(),
-		PodName: podName,
-	}
 }

--- a/api/jobs/get_legacy_job.go
+++ b/api/jobs/get_legacy_job.go
@@ -1,0 +1,350 @@
+package jobs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	jobModels "github.com/equinor/radix-api/api/jobs/models"
+	"github.com/equinor/radix-api/api/utils"
+	"github.com/equinor/radix-operator/pkg/apis/kube"
+	"github.com/equinor/radix-operator/pkg/apis/pipeline"
+	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	crdUtils "github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/equinor/radix-operator/pkg/apis/utils/git"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// JIRA : https://equinor.atlassian.net/browse/RA-725
+// TODO : Remove this entire file and all references to it when radixjobs has been in prod for a while
+func (jh JobHandler) getLatestJobPerApplicationLegacy(forApplications map[string]bool) (map[string]*jobModels.JobSummary, error) {
+	jobList, err := jh.getAllJobsLegacy()
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(jobList.Items, func(i, j int) bool {
+		switch strings.Compare(jobList.Items[i].Labels[kube.RadixAppLabel], jobList.Items[j].Labels[kube.RadixAppLabel]) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+		return jobList.Items[j].Status.StartTime.Before(jobList.Items[i].Status.StartTime)
+	})
+
+	applicationJob := make(map[string]*jobModels.JobSummary)
+	for _, job := range jobList.Items {
+		appName := job.Labels[kube.RadixAppLabel]
+		if applicationJob[appName] != nil {
+			continue
+		}
+		if forApplications[appName] != true {
+			continue
+		}
+
+		jobSummary, err := jh.getJobSummaryWithDeploymentLegacy(appName, &job, map[string][]string{})
+		if err != nil {
+			return nil, err
+		}
+
+		applicationJob[appName] = jobSummary
+	}
+
+	return applicationJob, nil
+}
+
+func (jh JobHandler) getApplicationJobsLegacy(appName string) ([]*jobModels.JobSummary, error) {
+	jobList, err := jh.getJobsLegacy(appName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort jobs descending
+	sort.Slice(jobList.Items, func(i, j int) bool {
+		return jobList.Items[j].Status.StartTime.Before(jobList.Items[i].Status.StartTime)
+	})
+
+	jobEnvironmentsMap, err := jh.getJobEnvironmentMapLegacy(appName)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]*jobModels.JobSummary, len(jobList.Items))
+	for i, job := range jobList.Items {
+		jobSummary, err := jh.getJobSummaryWithDeploymentLegacy(appName, &job, jobEnvironmentsMap)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs[i] = jobSummary
+	}
+
+	return jobs, nil
+}
+
+// TODO : Remove when radixjobs has been in prod for a while
+func (jh JobHandler) getApplicationJobLegacy(appName, jobName string) (*jobModels.Job, error) {
+	job, err := jh.userAccount.Client.BatchV1().Jobs(crdUtils.GetAppNamespace(appName)).Get(jobName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil, jobModels.PipelineNotFoundError(appName, jobName)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.EqualFold(job.Labels[kube.RadixJobTypeLabel], RadixJobTypeJob) {
+		return nil, utils.ValidationError("Radix Application Job", "Job was not of expected type")
+	}
+
+	steps, err := jh.getJobStepsLegacy(appName, job)
+	if err != nil {
+		return nil, err
+	}
+
+	jobDeployments, err := jh.deploy.GetDeploymentsForJob(appName, jobName)
+	if err != nil {
+		return nil, err
+	}
+
+	jobComponents, err := jh.getJobComponents(appName, jobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return jobModels.GetJob(job, steps, jobDeployments, jobComponents), nil
+}
+
+// TODO : Remove when radixjobs has been in prod for a while
+func (jh JobHandler) getJobStepsLegacy(appName string, job *batchv1.Job) ([]jobModels.Step, error) {
+	steps := []jobModels.Step{}
+	jobName := job.GetName()
+
+	pipelinePod, err := jh.getPipelinePod(appName, jobName)
+	if err != nil {
+		return nil, err
+	} else if pipelinePod == nil {
+		return steps, nil
+	}
+
+	if len(pipelinePod.Status.ContainerStatuses) == 0 {
+		return steps, nil
+	}
+
+	pipelineType, _ := pipeline.GetPipelineFromName(job.Labels["radix-pipeline"])
+
+	switch pipelineType.Type {
+	case v1.Build, v1.BuildDeploy:
+		return jh.getJobStepsBuildPipelineLegacy(appName, pipelinePod, job)
+	case v1.Promote:
+		return jh.getJobStepsPromotePipelineLegacy(appName, pipelinePod, job)
+	}
+
+	return steps, nil
+}
+
+// TODO : Remove when radixjobs has been in prod for a while
+func (jh JobHandler) getJobStepsBuildPipelineLegacy(appName string, pipelinePod *corev1.Pod, job *batchv1.Job) ([]jobModels.Step, error) {
+	steps := []jobModels.Step{}
+	if len(pipelinePod.Status.InitContainerStatuses) == 0 {
+		return steps, nil
+	}
+
+	pipelineJobStep := getPipelineJobStep(pipelinePod)
+	cloneContainerStatus := getCloneContainerStatus(pipelinePod)
+	if cloneContainerStatus == nil {
+		return steps, nil
+	}
+
+	// Clone of radix config should be represented
+	pipelineCloneStep := getJobStep(pipelinePod.GetName(), cloneContainerStatus)
+	pipelineCloneStep.Name = "clone-config"
+
+	jobStepsLabelSelector := fmt.Sprintf("%s=%s, %s!=%s", kube.RadixImageTagLabel, job.Labels[kube.RadixImageTagLabel], kube.RadixJobTypeLabel, RadixJobTypeJob)
+
+	jobStepList, err := jh.userAccount.Client.BatchV1().Jobs(crdUtils.GetAppNamespace(appName)).List(metav1.ListOptions{
+		LabelSelector: jobStepsLabelSelector,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// pipeline coordinator
+	steps = append(steps, pipelineCloneStep, pipelineJobStep)
+	for _, jobStep := range jobStepList.Items {
+		jobStepPod, err := jh.userAccount.Client.CoreV1().Pods(crdUtils.GetAppNamespace(appName)).List(metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", "job-name", jobStep.Name),
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(jobStepPod.Items) == 0 {
+			continue
+		}
+
+		pod := jobStepPod.Items[0]
+		for _, containerStatus := range pod.Status.InitContainerStatuses {
+			if strings.HasPrefix(containerStatus.Name, git.InternalContainerPrefix) {
+				continue
+			}
+
+			steps = append(steps, getJobStep(pod.GetName(), &containerStatus))
+		}
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			steps = append(steps, getJobStep(pod.GetName(), &containerStatus))
+		}
+	}
+
+	return steps, nil
+}
+
+func (jh JobHandler) getJobStepsPromotePipelineLegacy(appName string, pipelinePod *corev1.Pod, job *batchv1.Job) ([]jobModels.Step, error) {
+	steps := []jobModels.Step{}
+	pipelineJobStep := getJobStep(pipelinePod.GetName(), &pipelinePod.Status.ContainerStatuses[0])
+	steps = append(steps, pipelineJobStep)
+	return steps, nil
+}
+
+// TODO : Remove when radixjobs has been in prod for a while
+// GetJobSummaryWithDeployment Used to get job summary from a kubernetes job
+func (jh JobHandler) getJobSummaryWithDeploymentLegacy(appName string, job *batchv1.Job, jobEnvironmentsMap map[string][]string) (*jobModels.JobSummary, error) {
+	jobSummary := jobModels.GetJobSummary(job)
+	jobSummary.Environments = jobEnvironmentsMap[job.Name]
+	return jobSummary, nil
+}
+
+// TODO : Remove when radixjobs has been in prod for a while
+func (jh JobHandler) getJobEnvironmentMapLegacy(appName string) (map[string][]string, error) {
+	allDeployments, err := jh.deploy.GetDeploymentsForApplication(appName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	jobEnvironmentsMap := make(map[string][]string)
+	for _, deployment := range allDeployments {
+		if jobEnvironmentsMap[deployment.CreatedByJob] == nil {
+			environments := make([]string, 1)
+			environments[0] = deployment.Environment
+			jobEnvironmentsMap[deployment.CreatedByJob] = environments
+		} else {
+			environments := jobEnvironmentsMap[deployment.CreatedByJob]
+			environments = append(environments, deployment.Environment)
+			jobEnvironmentsMap[deployment.CreatedByJob] = environments
+		}
+	}
+
+	return jobEnvironmentsMap, nil
+}
+
+func (jh JobHandler) getPipelinePod(appName, jobName string) (*corev1.Pod, error) {
+	ns := crdUtils.GetAppNamespace(appName)
+	pods, err := jh.userAccount.Client.CoreV1().Pods(ns).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", "job-name", jobName),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) == 0 {
+		// pipeline pod not found
+		return nil, nil
+	}
+
+	return &pods.Items[0], nil
+}
+
+func (jh JobHandler) getAllJobsLegacy() (*batchv1.JobList, error) {
+	return jh.getJobsInNamespaceLegacy(jh.serviceAccount.Client, corev1.NamespaceAll)
+}
+
+func (jh JobHandler) getJobsLegacy(appName string) (*batchv1.JobList, error) {
+	return jh.getJobsInNamespaceLegacy(jh.userAccount.Client, crdUtils.GetAppNamespace(appName))
+}
+
+func (jh JobHandler) getJobsInNamespaceLegacy(kubeClient kubernetes.Interface, namespace string) (*batchv1.JobList, error) {
+	jobList, err := kubeClient.BatchV1().Jobs(namespace).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", kube.RadixJobTypeLabel, RadixJobTypeJob),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return jobList, nil
+}
+
+func getPipelineJobStep(pipelinePod *corev1.Pod) jobModels.Step {
+	var pipelineJobStep jobModels.Step
+
+	cloneContainerStatus := getCloneContainerStatus(pipelinePod)
+	if cloneContainerStatus == nil {
+		return jobModels.Step{}
+	}
+
+	if cloneContainerStatus.State.Terminated != nil &&
+		cloneContainerStatus.State.Terminated.ExitCode > 0 {
+		pipelineJobStep = getJobStepWithContainerName(pipelinePod.GetName(),
+			pipelinePod.Status.ContainerStatuses[0].Name, cloneContainerStatus)
+	} else {
+		pipelineJobStep = getJobStep(pipelinePod.GetName(), &pipelinePod.Status.ContainerStatuses[0])
+	}
+
+	return pipelineJobStep
+}
+
+func getCloneContainerStatus(pipelinePod *corev1.Pod) *corev1.ContainerStatus {
+	for _, containerStatus := range pipelinePod.Status.InitContainerStatuses {
+		if containerStatus.Name == git.CloneContainerName {
+			return &containerStatus
+		}
+	}
+
+	return nil
+}
+
+func getJobStep(podName string, containerStatus *corev1.ContainerStatus) jobModels.Step {
+	return getJobStepWithContainerName(podName, containerStatus.Name, containerStatus)
+}
+
+func getJobStepWithContainerName(podName, containerName string, containerStatus *corev1.ContainerStatus) jobModels.Step {
+	var startedAt metav1.Time
+	var finishedAt metav1.Time
+
+	status := jobModels.Succeeded
+
+	if containerStatus == nil {
+		status = jobModels.Waiting
+
+	} else if containerStatus.State.Terminated != nil {
+		startedAt = containerStatus.State.Terminated.StartedAt
+		finishedAt = containerStatus.State.Terminated.FinishedAt
+
+		if containerStatus.State.Terminated.ExitCode > 0 {
+			status = jobModels.Failed
+		}
+
+	} else if containerStatus.State.Running != nil {
+		startedAt = containerStatus.State.Running.StartedAt
+		status = jobModels.Running
+
+	} else if containerStatus.State.Waiting != nil {
+		status = jobModels.Waiting
+
+	}
+
+	return jobModels.Step{
+		Name:    containerName,
+		Started: utils.FormatTime(&startedAt),
+		Ended:   utils.FormatTime(&finishedAt),
+		Status:  status.String(),
+		PodName: podName,
+	}
+}

--- a/api/jobs/job_controller.go
+++ b/api/jobs/job_controller.go
@@ -50,6 +50,11 @@ func (jc *jobController) GetRoutes() models.Routes {
 			Method:      "GET",
 			HandlerFunc: GetApplicationJob,
 		},
+		models.Route{
+			Path:        rootPath + "/jobs/{jobName}/stop",
+			Method:      "POST",
+			HandlerFunc: StopApplicationJob,
+		},
 	}
 
 	return routes
@@ -294,4 +299,51 @@ func GetApplicationJob(clients models.Clients, w http.ResponseWriter, r *http.Re
 	}
 
 	utils.JSONResponse(w, r, jobDetail)
+}
+
+// StopApplicationJob Stops job
+func StopApplicationJob(clients models.Clients, w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /applications/{appName}/jobs/{jobName}/stop job stopApplicationJob
+	// ---
+	// summary: Stops job
+	// parameters:
+	// - name: appName
+	//   in: path
+	//   description: name of application
+	//   type: string
+	//   required: true
+	// - name: jobName
+	//   in: path
+	//   description: name of job
+	//   type: string
+	//   required: true
+	// - name: Impersonate-User
+	//   in: header
+	//   description: Works only with custom setup of cluster. Allow impersonation of test users (Required if Impersonate-Group is set)
+	//   type: string
+	//   required: false
+	// - name: Impersonate-Group
+	//   in: header
+	//   description: Works only with custom setup of cluster. Allow impersonation of test group (Required if Impersonate-User is set)
+	//   type: string
+	//   required: false
+	// responses:
+	//   "200":
+	//     description: "Job stopped ok"
+	//   "401":
+	//     description: "Unauthorized"
+	//   "404":
+	//     description: "Not found"
+	appName := mux.Vars(r)["appName"]
+	jobName := mux.Vars(r)["jobName"]
+
+	handler := Init(clients.OutClusterClient, clients.OutClusterRadixClient, clients.InClusterClient, clients.InClusterRadixClient)
+	err := handler.StopJob(appName, jobName)
+
+	if err != nil {
+		utils.ErrorResponse(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/api/jobs/log_handler.go
+++ b/api/jobs/log_handler.go
@@ -22,7 +22,7 @@ func (jh JobHandler) HandleGetApplicationJobLogs(appName, jobName string) ([]job
 		return nil, err
 	}
 
-	steps, err := jh.getJobSteps(appName, job)
+	steps, err := jh.getJobStepsLegacy(appName, job)
 	if err != nil {
 		return nil, err
 	}

--- a/api/jobs/models/job.go
+++ b/api/jobs/models/job.go
@@ -4,6 +4,7 @@ import (
 	deploymentModels "github.com/equinor/radix-api/api/deployments/models"
 	"github.com/equinor/radix-api/api/utils"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
+	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,6 +29,12 @@ type Job struct {
 	// required: false
 	// example: 4faca8595c5283a9d0f17a623b9255a0d9866a2e
 	CommitID string `json:"commitID"`
+
+	// Created timestamp
+	//
+	// required: false
+	// example: 2006-01-02T15:04:05Z
+	Created string `json:"created"`
 
 	// Started timestamp
 	//
@@ -93,10 +100,48 @@ func GetJob(job *batchv1.Job, steps []Step, jobDeployments []*deploymentModels.D
 		Name:        job.GetName(),
 		Branch:      getBranchFromAnnotation(job),
 		CommitID:    job.Labels[kube.RadixCommitLabel],
+		Created:     utils.FormatTime(&job.CreationTimestamp),
 		Started:     utils.FormatTime(job.Status.StartTime),
 		Ended:       utils.FormatTime(&jobEnded),
 		Status:      jobStatus.String(),
 		Pipeline:    job.Labels["radix-pipeline"],
+		Steps:       steps,
+		Deployments: jobDeployments,
+		Components:  jobComponents,
+	}
+}
+
+// GetJobFromRadixJob Gets job from a radix job
+func GetJobFromRadixJob(job *v1.RadixJob, jobDeployments []*deploymentModels.DeploymentSummary, jobComponents []*deploymentModels.ComponentSummary) *Job {
+	var steps []Step
+	for _, jobStep := range job.Status.Steps {
+		step := Step{
+			Name:    jobStep.Name,
+			Status:  string(jobStep.Condition),
+			Started: utils.FormatTime(jobStep.Started),
+			Ended:   utils.FormatTime(jobStep.Ended),
+			PodName: jobStep.PodName,
+		}
+
+		steps = append(steps, step)
+	}
+
+	created := utils.FormatTime(&job.CreationTimestamp)
+	if job.Status.Created != nil {
+		// Use this instead, because in a migration this may be more correct
+		// as migrated jobs will have the same creation timestamp in the new cluster
+		created = utils.FormatTime(job.Status.Created)
+	}
+
+	return &Job{
+		Name:        job.GetName(),
+		Branch:      job.Spec.Build.Branch,
+		CommitID:    job.Spec.Build.CommitID,
+		Created:     created,
+		Started:     utils.FormatTime(job.Status.Started),
+		Ended:       utils.FormatTime(job.Status.Ended),
+		Status:      GetStatusFromRadixJobStatus(job.Status),
+		Pipeline:    string(job.Spec.PipeLineType),
 		Steps:       steps,
 		Deployments: jobDeployments,
 		Components:  jobComponents,

--- a/api/jobs/models/progress_status.go
+++ b/api/jobs/models/progress_status.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 
+	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	batchv1 "k8s.io/api/batch/v1"
 )
 
@@ -54,4 +55,14 @@ func GetStatusFromJobStatus(jobStatus batchv1.JobStatus) ProgressStatus {
 	}
 
 	return status
+}
+
+// GetStatusFromRadixJobStatus Returns job status as string
+func GetStatusFromRadixJobStatus(jobStatus v1.RadixJobStatus) string {
+	if jobStatus.Condition != "" {
+		return string(jobStatus.Condition)
+	}
+
+	// radix-operator still hasn't picked up the job
+	return Waiting.String()
 }

--- a/api/jobs/start_job_handler.go
+++ b/api/jobs/start_job_handler.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -10,11 +9,10 @@ import (
 	"github.com/equinor/radix-api/api/metrics"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	pipelineJob "github.com/equinor/radix-operator/pkg/apis/pipeline"
+	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
-	"github.com/equinor/radix-operator/pkg/apis/utils/git"
+	k8sObjectUtils "github.com/equinor/radix-operator/pkg/apis/utils"
 	log "github.com/sirupsen/logrus"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,56 +23,65 @@ const (
 
 // HandleStartPipelineJob Handles the creation of a pipeline job for an application
 func (jh JobHandler) HandleStartPipelineJob(appName, sshRepo string, pipeline *pipelineJob.Definition, jobSpec *jobModels.JobParameters) (*jobModels.JobSummary, error) {
-	job := createPipelineJob(appName, sshRepo, pipeline, jobSpec)
+	radixRegistation, _ := jh.userAccount.RadixClient.RadixV1().RadixRegistrations().Get(appName, metav1.GetOptions{})
+	job := createPipelineJob(appName, radixRegistation.Spec.CloneURL, pipeline, jobSpec)
 
 	log.Infof("Starting job: %s, %s", job.GetName(), workerImage)
-	appNamespace := fmt.Sprintf("%s-app", appName)
-	job, err := jh.serviceAccount.Client.BatchV1().Jobs(appNamespace).Create(job)
+	appNamespace := k8sObjectUtils.GetAppNamespace(appName)
+	job, err := jh.serviceAccount.RadixClient.RadixV1().RadixJobs(appNamespace).Create(job)
 	if err != nil {
 		return nil, err
 	}
 
-	metrics.AddJobTriggered(appName, pipeline.Name)
+	metrics.AddJobTriggered(appName, string(pipeline.Type))
 
 	log.Infof("Started job: %s, %s", job.GetName(), workerImage)
-	return jobModels.GetJobSummary(job), nil
+	return jobModels.GetSummaryFromRadixJob(job), nil
 }
 
-func createPipelineJob(appName, sshURL string, pipeline *pipelineJob.Definition, jobSpec *jobModels.JobParameters) *batchv1.Job {
-	backOffLimit := int32(0)
+func createPipelineJob(appName, cloneURL string, pipeline *pipelineJob.Definition, jobSpec *jobModels.JobParameters) *v1.RadixJob {
+
 	jobName, randomStr := getUniqueJobName(workerImage)
 	dockerRegistry := os.Getenv(containerRegistryEnvironmentVariable)
-	imageTag := fmt.Sprintf("%s/%s:%s", dockerRegistry, workerImage, getPipelineTag())
 
-	log.Infof("Using image: %s", imageTag)
+	var buildSpec v1.RadixBuildSpec
+	var promoteSpec v1.RadixPromoteSpec
 
-	job := batchv1.Job{
+	switch pipeline.Type {
+	case v1.BuildDeploy, v1.Build:
+		buildSpec = v1.RadixBuildSpec{
+			ImageTag:      randomStr,
+			Branch:        jobSpec.Branch,
+			CommitID:      jobSpec.CommitID,
+			PushImage:     jobSpec.PushImage,
+			RadixFileName: "/workspace/radixconfig.yaml",
+		}
+	case v1.Promote:
+		promoteSpec = v1.RadixPromoteSpec{
+			DeploymentName:  jobSpec.DeploymentName,
+			FromEnvironment: jobSpec.FromEnvironment,
+			ToEnvironment:   jobSpec.ToEnvironment,
+		}
+	}
+
+	job := v1.RadixJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   jobName,
-			Labels: getPipelineJobLabels(appName, jobName, randomStr, pipeline, jobSpec),
+			Name: jobName,
+			Labels: map[string]string{
+				kube.RadixAppLabel: appName,
+			},
 			Annotations: map[string]string{
 				kube.RadixBranchAnnotation: jobSpec.Branch,
 			},
 		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: &backOffLimit,
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					ServiceAccountName: "radix-pipeline",
-					InitContainers:     getPipelineJobInitContainers(sshURL, pipeline),
-					Containers: []corev1.Container{
-						{
-							Name:            workerImage,
-							Image:           imageTag,
-							ImagePullPolicy: corev1.PullAlways,
-							Args:            getPipelineJobArguments(appName, jobName, randomStr, pipeline, jobSpec),
-							VolumeMounts:    getPipelineJobContainerVolumeMounts(pipeline),
-						},
-					},
-					Volumes:       getPipelineJobVolumes(pipeline),
-					RestartPolicy: "Never",
-				},
-			},
+		Spec: v1.RadixJobSpec{
+			AppName:        appName,
+			CloneURL:       cloneURL,
+			PipeLineType:   pipeline.Type,
+			PipelineImage:  getPipelineTag(),
+			DockerRegistry: dockerRegistry,
+			Build:          buildSpec,
+			Promote:        promoteSpec,
 		},
 	}
 
@@ -106,98 +113,4 @@ func getUniqueJobName(image string) (string, string) {
 func getCurrentTimestamp() string {
 	t := time.Now()
 	return t.Format("20060102150405") // YYYYMMDDHHMISS in Go
-}
-
-func getPipelineJobInitContainers(sshURL string, pipeline *pipelineJob.Definition) []corev1.Container {
-	var initContainers []corev1.Container
-
-	switch pipeline.Name {
-	case pipelineJob.BuildDeploy, pipelineJob.Build:
-		initContainers = git.CloneInitContainers(sshURL, "master")
-	}
-	return initContainers
-}
-
-func getPipelineJobArguments(appName string, jobName string, randomStr string, pipeline *pipelineJob.Definition, jobSpec *jobModels.JobParameters) []string {
-	// Base arguments for all types of pipeline
-	args := []string{
-		fmt.Sprintf("JOB_NAME=%s", jobName),
-		fmt.Sprintf("PIPELINE_TYPE=%s", pipeline.Name),
-	}
-
-	switch pipeline.Name {
-	case pipelineJob.BuildDeploy:
-		args = append(args, fmt.Sprintf("IMAGE_TAG=%s", randomStr))
-		fallthrough
-	case pipelineJob.Build:
-		args = append(args, fmt.Sprintf("BRANCH=%s", jobSpec.Branch))
-		args = append(args, fmt.Sprintf("COMMIT_ID=%s", jobSpec.CommitID))
-		args = append(args, fmt.Sprintf("PUSH_IMAGE=%s", jobSpec.GetPushImageTag()))
-		args = append(args, fmt.Sprintf("RADIX_FILE_NAME=%s", "/workspace/radixconfig.yaml"))
-	case pipelineJob.Promote:
-		args = append(args, fmt.Sprintf("RADIX_APP=%s", appName))
-		args = append(args, fmt.Sprintf("DEPLOYMENT_NAME=%s", jobSpec.DeploymentName))
-		args = append(args, fmt.Sprintf("FROM_ENVIRONMENT=%s", jobSpec.FromEnvironment))
-		args = append(args, fmt.Sprintf("TO_ENVIRONMENT=%s", jobSpec.ToEnvironment))
-	}
-
-	return args
-}
-
-func getPipelineJobLabels(appName string, jobName string, randomStr string, pipeline *pipelineJob.Definition, jobSpec *jobModels.JobParameters) map[string]string {
-	// Base labels for all types of pipeline
-	labels := map[string]string{
-		kube.RadixJobNameLabel: jobName,
-		kube.RadixJobTypeLabel: RadixJobTypeJob,
-		"radix-pipeline":       pipeline.Name,
-		"radix-app-name":       appName, // For backwards compatibility. Remove when cluster is migrated
-		kube.RadixAppLabel:     appName,
-	}
-
-	switch pipeline.Name {
-	case pipelineJob.BuildDeploy:
-		labels[kube.RadixImageTagLabel] = randomStr
-		fallthrough
-	case pipelineJob.Build:
-		labels[kube.RadixCommitLabel] = jobSpec.CommitID
-	}
-
-	return labels
-}
-
-func getPipelineJobContainerVolumeMounts(pipeline *pipelineJob.Definition) []corev1.VolumeMount {
-	var volumeMounts []corev1.VolumeMount
-
-	switch pipeline.Name {
-	case pipelineJob.BuildDeploy, pipelineJob.Build:
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      git.BuildContextVolumeName,
-			MountPath: git.Workspace,
-		})
-	}
-
-	return volumeMounts
-}
-
-func getPipelineJobVolumes(pipeline *pipelineJob.Definition) []corev1.Volume {
-	var volumes []corev1.Volume
-	defaultMode := int32(256)
-
-	switch pipeline.Name {
-	case pipelineJob.BuildDeploy, pipelineJob.Build:
-		volumes = append(volumes, corev1.Volume{
-			Name: git.BuildContextVolumeName,
-		})
-		volumes = append(volumes, corev1.Volume{
-			Name: git.GitSSHKeyVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName:  git.GitSSHKeyVolumeName,
-					DefaultMode: &defaultMode,
-				},
-			},
-		})
-	}
-
-	return volumes
 }

--- a/api/jobs/stop_job_handler.go
+++ b/api/jobs/stop_job_handler.go
@@ -1,0 +1,34 @@
+package jobs
+
+import (
+	"fmt"
+
+	jobModels "github.com/equinor/radix-api/api/jobs/models"
+	crdUtils "github.com/equinor/radix-operator/pkg/apis/utils"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StopJob Stops an application job
+func (jh JobHandler) StopJob(appName, jobName string) error {
+	log.Infof("Stopping job: %s, %s", jobName, appName)
+	appNamespace := crdUtils.GetAppNamespace(appName)
+	job, err := jh.serviceAccount.RadixClient.RadixV1().RadixJobs(appNamespace).Get(jobName, metav1.GetOptions{})
+
+	if errors.IsNotFound(err) {
+		return jobModels.PipelineNotFoundError(appName, jobName)
+	}
+	if err != nil {
+		return err
+	}
+
+	job.Spec.Stop = true
+
+	_, err = jh.userAccount.RadixClient.RadixV1().RadixJobs(appNamespace).Update(job)
+	if err != nil {
+		return fmt.Errorf("Failed to patch job object: %v", err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@
 // This is the API Server for the Radix platform.
 // Schemes: https, http
 // BasePath: /api/v1
-// Version: 0.0.95
+// Version: 0.0.96
 // Contact: https://equinor.slack.com/messages/CBKM6N2JY
 //
 // Consumes:


### PR DESCRIPTION
* Use deployment status

* Use RadixJob to trigger pipeline

* Use latest version of radix-operator

* Get job information from radix job

* Now get all jobs as radix jobs, when exist. Or else,
get legacy jobs

* Newer version of the API

* Added a method to stop a radix job

* Strategic patch does not work for CRD

* Fix compile errors

* Added test of API using radixjob

* Added created field on job

* Added uncheduled status

* Should be waiting

* Filter queued and unscheduled jobs from app
summary

* Use created timestamp from status when
available

* After code review

* Clone URL should be set from the API side

* Dep ensured