### PR TITLE
define unique operationId for swagger spec

### DIFF
--- a/api/environments/environment_controller.go
+++ b/api/environments/environment_controller.go
@@ -643,7 +643,7 @@ func RestartComponent(accounts models.Accounts, w http.ResponseWriter, r *http.R
 
 // GetPodLog Get logs of a single pod
 func GetPodLog(accounts models.Accounts, w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /applications/{appName}/environments/{envName}/components/{componentName}/replicas/{podName}/logs component log
+	// swagger:operation GET /applications/{appName}/environments/{envName}/components/{componentName}/replicas/{podName}/logs component replicaLog
 	// ---
 	// summary: Get logs from a deployed pod
 	// parameters:
@@ -720,7 +720,7 @@ func GetPodLog(accounts models.Accounts, w http.ResponseWriter, r *http.Request)
 
 // GetScheduledJobLog Get log from a scheduled job
 func GetScheduledJobLog(accounts models.Accounts, w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /applications/{appName}/environments/{envName}/jobcomponents/{jobComponentName}/scheduledjobs/{scheduledJobName}/logs job log
+	// swagger:operation GET /applications/{appName}/environments/{envName}/jobcomponents/{jobComponentName}/scheduledjobs/{scheduledJobName}/logs job jobLog
 	// ---
 	// summary: Get log from a scheduled job
 	// parameters:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4,7 +4,7 @@
 //
 //     Schemes: http, https
 //     BasePath: /api/v1
-//     Version: 1.9.2
+//     Version: 1.9.3
 //     Contact: https://equinor.slack.com/messages/CBKM6N2JY
 //
 //     Consumes:


### PR DESCRIPTION
The previous value **log** is used by swagger_gen as the value for field **operationId**. This value must be unique.
Renamed to **replicaLog** for replica logs, and **jobLog** for job logs to meet uniqueness requirement

