### PR TITLE
set default status of replicasummary earlier

### DIFF
--- a/api/deployments/models/component_deployment.go
+++ b/api/deployments/models/component_deployment.go
@@ -249,15 +249,16 @@ func GetReplicaSummary(pod corev1.Pod) ReplicaSummary {
 	replicaSummary.Name = pod.GetName()
 	creationTimestamp := pod.GetCreationTimestamp()
 	replicaSummary.Created = radixutils.FormatTimestamp(creationTimestamp.Time)
+
+	// Set default Pending status
+	replicaSummary.Status = ReplicaStatus{Status: Pending.String()}
+
 	if len(pod.Status.ContainerStatuses) <= 0 {
 		return replicaSummary
 	}
 	// We assume one component container per component pod
 	containerStatus := pod.Status.ContainerStatuses[0]
 	containerState := containerStatus.State
-
-	// Set default Pending status
-	replicaSummary.Status = ReplicaStatus{Status: Pending.String()}
 
 	if containerState.Waiting != nil {
 		replicaSummary.StatusMessage = containerState.Waiting.Message

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4,7 +4,7 @@
 //
 //     Schemes: http, https
 //     BasePath: /api/v1
-//     Version: 1.13.0
+//     Version: 1.13.1
 //     Contact: https://equinor.slack.com/messages/CBKM6N2JY
 //
 //     Consumes:


### PR DESCRIPTION
this is to have a default status before returning replicaSummary.
otherwise, if i.e. the persistent volume claim is invalid the returned summary will have a missing value for replica status.
When pvc is not created, the pod's containerStatuses list is empty, and this list is where the replica status is read from.