### PR TITLE
61455 include oauth only public component

### DIFF
--- a/api/deployments/component_controller_test.go
+++ b/api/deployments/component_controller_test.go
@@ -256,10 +256,21 @@ func TestGetComponents_OAuth2(t *testing.T) {
 	var components []deploymentModels.Component
 	controllertest.GetResponseBody(response, &components)
 
-	assert.ElementsMatch(t, []string{"c1" + suffix.OAuth2ClientSecret, "c1" + suffix.OAuth2CookieSecret}, getComponentByName("c1", components).Secrets)
-	assert.ElementsMatch(t, []string{"c2" + suffix.OAuth2ClientSecret, "c2" + suffix.OAuth2CookieSecret, "c2" + suffix.OAuth2RedisPassword}, getComponentByName("c2", components).Secrets)
-	assert.Empty(t, getComponentByName("c3", components).Secrets)
-	assert.Empty(t, getComponentByName("c4", components).Secrets)
+	actualComponent := getComponentByName("c1", components)
+	assert.NotNil(t, actualComponent.AuxiliaryResource.OAuth2)
+	assert.ElementsMatch(t, []string{"c1" + suffix.OAuth2ClientSecret, "c1" + suffix.OAuth2CookieSecret}, actualComponent.Secrets)
+
+	actualComponent = getComponentByName("c2", components)
+	assert.NotNil(t, actualComponent.AuxiliaryResource.OAuth2)
+	assert.ElementsMatch(t, []string{"c2" + suffix.OAuth2ClientSecret, "c2" + suffix.OAuth2CookieSecret, "c2" + suffix.OAuth2RedisPassword}, actualComponent.Secrets)
+
+	actualComponent = getComponentByName("c3", components)
+	assert.Nil(t, actualComponent.AuxiliaryResource.OAuth2)
+	assert.Empty(t, actualComponent.Secrets)
+
+	actualComponent = getComponentByName("c4", components)
+	assert.Nil(t, actualComponent.AuxiliaryResource.OAuth2)
+	assert.Empty(t, actualComponent.Secrets)
 }
 
 func TestGetComponents_inactive_deployment(t *testing.T) {

--- a/api/deployments/component_handler.go
+++ b/api/deployments/component_handler.go
@@ -369,7 +369,7 @@ func getReplicaSummaryList(pods []corev1.Pod) []deploymentModels.ReplicaSummary 
 }
 
 func getAuxiliaryResources(kubeClient kubernetes.Interface, appName string, component v1.RadixCommonDeployComponent, envNamespace string) (auxResource deploymentModels.AuxiliaryResource, err error) {
-	if auth := component.GetAuthentication(); auth != nil && auth.OAuth2 != nil {
+	if auth := component.GetAuthentication(); component.IsPublic() && auth != nil && auth.OAuth2 != nil {
 		auxResource.OAuth2, err = getOAuth2AuxiliaryResource(kubeClient, appName, component.GetName(), envNamespace, *auth.OAuth2)
 		if err != nil {
 			return

--- a/api/deployments/models/component_builder.go
+++ b/api/deployments/models/component_builder.go
@@ -115,7 +115,7 @@ func (b *componentBuilder) WithComponent(component v1.RadixCommonDeployComponent
 			b.secrets = append(b.secrets, secretName+defaults.BlobFuseCredsAccountKeyPartSuffix)
 			b.secrets = append(b.secrets, secretName+defaults.BlobFuseCredsAccountNamePartSuffix)
 		case v1.MountTypeBlobCsiAzure, v1.MountTypeFileCsiAzure:
-			secretName := defaults.GetCsiAzureCredsSecretName(component.GetName(), volumeMount.Name)
+			secretName := defaults.GetCsiAzureVolumeMountCredsSecretName(component.GetName(), volumeMount.Name)
 			b.secrets = append(b.secrets, secretName+defaults.CsiAzureCredsAccountKeyPartSuffix)
 			b.secrets = append(b.secrets, secretName+defaults.CsiAzureCredsAccountNamePartSuffix)
 		}

--- a/api/secrets/secret_controller_test.go
+++ b/api/secrets/secret_controller_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	commontest "github.com/equinor/radix-operator/pkg/apis/test"
-	k8sObjectUtils "github.com/equinor/radix-operator/pkg/apis/utils"
 	operatorutils "github.com/equinor/radix-operator/pkg/apis/utils"
 	radixclient "github.com/equinor/radix-operator/pkg/client/clientset/versioned"
 	"github.com/equinor/radix-operator/pkg/client/clientset/versioned/fake"
@@ -870,7 +869,7 @@ func Test_GetSecretsForDeployment_OAuth2(t *testing.T) {
 	kubeclient.CoreV1().Secrets(envNs).Create(
 		context.Background(),
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: k8sObjectUtils.GetAuxiliaryComponentSecretName(component1Name, defaults.OAuthProxyAuxiliaryComponentSuffix)},
+			ObjectMeta: metav1.ObjectMeta{Name: operatorutils.GetAuxiliaryComponentSecretName(component1Name, defaults.OAuthProxyAuxiliaryComponentSuffix)},
 			Data:       map[string][]byte{defaults.OAuthClientSecretKeyName: []byte("client secret")},
 		},
 		metav1.CreateOptions{},
@@ -878,7 +877,7 @@ func Test_GetSecretsForDeployment_OAuth2(t *testing.T) {
 	comp2Secret, _ := kubeclient.CoreV1().Secrets(envNs).Create(
 		context.Background(),
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: k8sObjectUtils.GetAuxiliaryComponentSecretName(component2Name, defaults.OAuthProxyAuxiliaryComponentSuffix)},
+			ObjectMeta: metav1.ObjectMeta{Name: operatorutils.GetAuxiliaryComponentSecretName(component2Name, defaults.OAuthProxyAuxiliaryComponentSuffix)},
 			Data:       map[string][]byte{defaults.OAuthCookieSecretKeyName: []byte("cookie secret")},
 		},
 		metav1.CreateOptions{},

--- a/api/secrets/secret_handler.go
+++ b/api/secrets/secret_handler.go
@@ -193,9 +193,7 @@ func (eh SecretHandler) GetSecretsForDeployment(appName, envName, deploymentName
 	}
 
 	secrets := make([]models.Secret, 0)
-	for _, secretFromVolumeMounts := range secretsFromVolumeMounts {
-		secrets = append(secrets, secretFromVolumeMounts)
-	}
+	secrets = append(secrets, secretsFromVolumeMounts...)
 
 	for _, secretFromTLSCertificate := range secretsFromTLSCertificates {
 		secrets = append(secrets, secretFromTLSCertificate)
@@ -373,7 +371,7 @@ func (eh SecretHandler) getBlobFuseSecrets(component v1.RadixCommonDeployCompone
 
 func (eh SecretHandler) getCsiAzureSecrets(component v1.RadixCommonDeployComponent, envNamespace string, volumeMount v1.RadixVolumeMount) (models.Secret, models.Secret) {
 	return eh.getAzureVolumeMountSecrets(envNamespace, component,
-		defaults.GetCsiAzureCredsSecretName(component.GetName(), volumeMount.Name),
+		defaults.GetCsiAzureVolumeMountCredsSecretName(component.GetName(), volumeMount.Name),
 		volumeMount.Name,
 		defaults.CsiAzureCredsAccountNamePart,
 		defaults.CsiAzureCredsAccountKeyPart,
@@ -516,7 +514,7 @@ func (eh SecretHandler) getSecretsFromComponentAuthenticationClientCertificate(c
 
 func (eh SecretHandler) getSecretsFromComponentAuthenticationOAuth2(component v1.RadixCommonDeployComponent, envNamespace string) ([]models.Secret, error) {
 	var secrets []models.Secret
-	if auth := component.GetAuthentication(); auth != nil && component.IsPublic() && auth.OAuth2 != nil {
+	if auth := component.GetAuthentication(); component.IsPublic() && auth != nil && auth.OAuth2 != nil {
 		oauth2, err := defaults.NewOAuth2Config(defaults.WithOAuth2Defaults()).MergeWith(auth.OAuth2)
 		if err != nil {
 			return nil, err

--- a/api/secrets/secret_handler_test.go
+++ b/api/secrets/secret_handler_test.go
@@ -39,9 +39,7 @@ type getSecretScenario struct {
 	components      []v1.RadixDeployComponent
 	jobs            []v1.RadixDeployJobComponent
 	externalAliases []v1.ExternalAlias
-	volumeMounts    []v1.RadixVolumeMount
 	existingSecrets []secretDescription
-	expectedError   bool
 	expectedSecrets []secretModels.Secret
 }
 
@@ -1008,12 +1006,12 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			components: []v1.RadixDeployComponent{{
 				Name: componentName1,
 			}},
-			secretName:                  defaults.GetCsiAzureCredsSecretName(componentName1, volumeName1),
+			secretName:                  defaults.GetCsiAzureVolumeMountCredsSecretName(componentName1, volumeName1),
 			secretDataKey:               defaults.CsiAzureCredsAccountNamePart,
 			secretValue:                 "currentAccountName",
 			secretExists:                true,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountName",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1025,12 +1023,12 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			jobs: []v1.RadixDeployJobComponent{{
 				Name: jobName1,
 			}},
-			secretName:                  defaults.GetCsiAzureCredsSecretName(jobName1, volumeName1),
+			secretName:                  defaults.GetCsiAzureVolumeMountCredsSecretName(jobName1, volumeName1),
 			secretDataKey:               defaults.CsiAzureCredsAccountNamePart,
 			secretValue:                 "currentAccountName",
 			secretExists:                true,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountName",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1044,7 +1042,7 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			}},
 			secretExists:                false,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountName",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1058,7 +1056,7 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			}},
 			secretExists:                false,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountNamePartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountName",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1070,12 +1068,12 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			components: []v1.RadixDeployComponent{{
 				Name: componentName1,
 			}},
-			secretName:                  defaults.GetCsiAzureCredsSecretName(componentName1, volumeName1),
+			secretName:                  defaults.GetCsiAzureVolumeMountCredsSecretName(componentName1, volumeName1),
 			secretDataKey:               defaults.CsiAzureCredsAccountKeyPart,
 			secretValue:                 "currentAccountKey",
 			secretExists:                true,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountKey",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1087,12 +1085,12 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			jobs: []v1.RadixDeployJobComponent{{
 				Name: jobName1,
 			}},
-			secretName:                  defaults.GetCsiAzureCredsSecretName(jobName1, volumeName1),
+			secretName:                  defaults.GetCsiAzureVolumeMountCredsSecretName(jobName1, volumeName1),
 			secretDataKey:               defaults.CsiAzureCredsAccountKeyPart,
 			secretValue:                 "currentAccountKey",
 			secretExists:                true,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountKey",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1106,7 +1104,7 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			}},
 			secretExists:                false,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(componentName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountKey",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,
@@ -1120,7 +1118,7 @@ func (s *secretHandlerTestSuite) TestSecretHandler_ChangeSecrets() {
 			}},
 			secretExists:                false,
 			changingSecretComponentName: componentName1,
-			changingSecretName:          defaults.GetCsiAzureCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
+			changingSecretName:          defaults.GetCsiAzureVolumeMountCredsSecretName(jobName1, volumeName1) + defaults.CsiAzureCredsAccountKeyPartSuffix,
 			changingSecretParams: secretModels.SecretParameters{
 				SecretValue: "newAccountKey",
 				Type:        secretModels.SecretTypeCsiAzureBlobVolume,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4,7 +4,7 @@
 //
 //     Schemes: http, https
 //     BasePath: /api/v1
-//     Version: 1.19.2
+//     Version: 1.19.3
 //     Contact: https://equinor.slack.com/messages/CBKM6N2JY
 //
 //     Consumes:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/equinor/radix-common v1.1.9
 	github.com/equinor/radix-job-scheduler v1.4.0
-	github.com/equinor/radix-operator v1.18.0
+	github.com/equinor/radix-operator v1.19.1
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/go-openapi/strfmt v0.20.1
 	github.com/golang-jwt/jwt/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -314,8 +314,8 @@ github.com/equinor/radix-common v1.1.9/go.mod h1:4gmUb9rZX5jC/XkmuUJnvm5yzRyD+je
 github.com/equinor/radix-job-scheduler v1.4.0 h1:v5a8Ba2IgBl0qJCuLyFphzxQB0/nlDqjksIY1RgBEy4=
 github.com/equinor/radix-job-scheduler v1.4.0/go.mod h1:WuZhnm/DXIsw+9/Kk2XoxsfzRUJJ46fUxWznDzNooe0=
 github.com/equinor/radix-operator v1.16.13/go.mod h1:WBz3AaeKuHYgkD9PuVnx0LNPYDC0eUdnFRqExPmHNd0=
-github.com/equinor/radix-operator v1.18.0 h1:z+3Ux589NbZXLlhOEMlEqyzOiuhyni3n0KbwcZuDO4c=
-github.com/equinor/radix-operator v1.18.0/go.mod h1:wnLMf/a0iing0l67L2Qt7E6fLrxIz6CF/Z11hDQCRXg=
+github.com/equinor/radix-operator v1.19.1 h1:m2HKohglsDlWH+FtUsUf1SBA7iTLyyDx332fgYamGWY=
+github.com/equinor/radix-operator v1.19.1/go.mod h1:wnLMf/a0iing0l67L2Qt7E6fLrxIz6CF/Z11hDQCRXg=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=


### PR DESCRIPTION
Do not return oauth2 information about deplpoyment status for non-public components.

Also updated radix-operator package reference => function GetCsiAzureCredsSecretName was renamed to GetCsiAzureVolumeMountCredsSecretName.