### PR TITLE
259799 add component identity info

### DIFF
--- a/api/deployments/component_controller_test.go
+++ b/api/deployments/component_controller_test.go
@@ -14,7 +14,6 @@ import (
 	radixutils "github.com/equinor/radix-common/utils"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
-	builders "github.com/equinor/radix-operator/pkg/apis/utils"
 	operatorUtils "github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +41,7 @@ func TestGetComponents_non_existing_app(t *testing.T) {
 
 func TestGetComponents_non_existing_deployment(t *testing.T) {
 	commonTestUtils, controllerTestUtils, _, _, _, _ := setupTest()
-	commonTestUtils.ApplyApplication(builders.
+	commonTestUtils.ApplyApplication(operatorUtils.
 		ARadixApplication().
 		WithAppName(anyAppName))
 
@@ -61,19 +60,19 @@ func TestGetComponents_non_existing_deployment(t *testing.T) {
 func TestGetComponents_active_deployment(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, kubeclient, _, _, _ := setupTest()
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job")).
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job")).
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app")).
+			operatorUtils.NewDeployComponentBuilder().WithName("app")).
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName(anyDeployName))
 
-	createComponentPod(kubeclient, "pod1", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app")
-	createComponentPod(kubeclient, "pod2", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app")
-	createComponentPod(kubeclient, "pod3", builders.GetEnvironmentNamespace(anyAppName, "dev"), "job")
+	createComponentPod(kubeclient, "pod1", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app")
+	createComponentPod(kubeclient, "pod2", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app")
+	createComponentPod(kubeclient, "pod3", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "job")
 
 	endpoint := createGetComponentsEndpoint(anyAppName, anyDeployName)
 
@@ -95,13 +94,13 @@ func TestGetComponents_active_deployment(t *testing.T) {
 func TestGetComponents_WithExternalAlias_ContainsTLSSecrets(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, client, radixclient, promclient, secretProviderClient := setupTest()
-	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, builders.ARadixDeployment().
+	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, operatorUtils.ARadixDeployment().
 		WithAppName("any-app").
 		WithEnvironment("prod").
 		WithDeploymentName(anyDeployName).
 		WithJobComponents().
 		WithComponents(
-			builders.NewDeployComponentBuilder().
+			operatorUtils.NewDeployComponentBuilder().
 				WithName("frontend").
 				WithPort("http", 8080).
 				WithPublicPort("http").
@@ -130,12 +129,12 @@ func TestGetComponents_WithExternalAlias_ContainsTLSSecrets(t *testing.T) {
 func TestGetComponents_WithVolumeMount_ContainsVolumeMountSecrets(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, client, radixclient, promclient, secretProviderClient := setupTest()
-	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, builders.ARadixDeployment().
+	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, operatorUtils.ARadixDeployment().
 		WithAppName("any-app").
 		WithEnvironment("prod").
 		WithDeploymentName(anyDeployName).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().
+			operatorUtils.NewDeployJobComponentBuilder().
 				WithName("job").
 				WithVolumeMounts(
 					v1.RadixVolumeMount{
@@ -147,7 +146,7 @@ func TestGetComponents_WithVolumeMount_ContainsVolumeMountSecrets(t *testing.T) 
 				),
 		).
 		WithComponents(
-			builders.NewDeployComponentBuilder().
+			operatorUtils.NewDeployComponentBuilder().
 				WithName("frontend").
 				WithPort("http", 8080).
 				WithPublicPort("http").
@@ -187,13 +186,13 @@ func TestGetComponents_WithVolumeMount_ContainsVolumeMountSecrets(t *testing.T) 
 func TestGetComponents_WithTwoVolumeMounts_ContainsTwoVolumeMountSecrets(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, client, radixclient, promclient, secretProviderClient := setupTest()
-	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, builders.ARadixDeployment().
+	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, operatorUtils.ARadixDeployment().
 		WithAppName("any-app").
 		WithEnvironment("prod").
 		WithDeploymentName(anyDeployName).
 		WithJobComponents().
 		WithComponents(
-			builders.NewDeployComponentBuilder().
+			operatorUtils.NewDeployComponentBuilder().
 				WithName("frontend").
 				WithPort("http", 8080).
 				WithPublicPort("http").
@@ -234,16 +233,16 @@ func TestGetComponents_WithTwoVolumeMounts_ContainsTwoVolumeMountSecrets(t *test
 func TestGetComponents_OAuth2(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, client, radixclient, promclient, secretProviderClient := setupTest()
-	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, builders.ARadixDeployment().
+	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, operatorUtils.ARadixDeployment().
 		WithAppName("any-app").
 		WithEnvironment("prod").
 		WithDeploymentName(anyDeployName).
 		WithJobComponents().
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("c1").WithPublicPort("http").WithAuthentication(&v1.Authentication{OAuth2: &v1.OAuth2{}}),
-			builders.NewDeployComponentBuilder().WithName("c2").WithPublicPort("http").WithAuthentication(&v1.Authentication{OAuth2: &v1.OAuth2{SessionStoreType: v1.SessionStoreRedis}}),
-			builders.NewDeployComponentBuilder().WithName("c3").WithPublicPort("http"),
-			builders.NewDeployComponentBuilder().WithName("c4").WithAuthentication(&v1.Authentication{OAuth2: &v1.OAuth2{}}),
+			operatorUtils.NewDeployComponentBuilder().WithName("c1").WithPublicPort("http").WithAuthentication(&v1.Authentication{OAuth2: &v1.OAuth2{}}),
+			operatorUtils.NewDeployComponentBuilder().WithName("c2").WithPublicPort("http").WithAuthentication(&v1.Authentication{OAuth2: &v1.OAuth2{SessionStoreType: v1.SessionStoreRedis}}),
+			operatorUtils.NewDeployComponentBuilder().WithName("c3").WithPublicPort("http"),
+			operatorUtils.NewDeployComponentBuilder().WithName("c4").WithAuthentication(&v1.Authentication{OAuth2: &v1.OAuth2{}}),
 		))
 
 	// Test
@@ -281,39 +280,39 @@ func TestGetComponents_inactive_deployment(t *testing.T) {
 	initialDeploymentCreated, _ := radixutils.ParseTimestamp("2018-11-12T11:45:26Z")
 	activeDeploymentCreated, _ := radixutils.ParseTimestamp("2018-11-14T11:45:26Z")
 
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName("initial-deployment").
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app"),
+			operatorUtils.NewDeployComponentBuilder().WithName("app"),
 		).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job"),
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job"),
 		).
 		WithCreated(initialDeploymentCreated).
 		WithCondition(v1.DeploymentInactive).
 		WithActiveFrom(initialDeploymentCreated).
 		WithActiveTo(activeDeploymentCreated))
 
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName("active-deployment").
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app"),
+			operatorUtils.NewDeployComponentBuilder().WithName("app"),
 		).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job"),
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job"),
 		).
 		WithCreated(activeDeploymentCreated).
 		WithCondition(v1.DeploymentActive).
 		WithActiveFrom(activeDeploymentCreated))
 
-	createComponentPod(kubeclient, "pod1", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app")
-	createComponentPod(kubeclient, "pod2", builders.GetEnvironmentNamespace(anyAppName, "dev"), "job")
+	createComponentPod(kubeclient, "pod1", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app")
+	createComponentPod(kubeclient, "pod2", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "job")
 
 	endpoint := createGetComponentsEndpoint(anyAppName, "initial-deployment")
 
@@ -351,7 +350,7 @@ func getPodSpec(podName, radixComponentLabel string) *corev1.Pod {
 func TestGetComponents_success(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, _, _, _, _ := setupTest()
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithDeploymentName(anyDeployName))
@@ -374,21 +373,21 @@ func TestGetComponents_success(t *testing.T) {
 func TestGetComponents_ReplicaStatus_Failing(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, kubeclient, _, _, _ := setupTest()
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName(anyDeployName).
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app")).
+			operatorUtils.NewDeployComponentBuilder().WithName("app")).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job")))
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job")))
 
 	message1 := "Couldn't find key TEST_SECRET in Secret radix-demo-hello-nodejs-dev/www"
-	createComponentPodWithContainerState(kubeclient, "pod1", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message1, deploymentModels.Failing, true)
-	createComponentPodWithContainerState(kubeclient, "pod2", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message1, deploymentModels.Failing, true)
+	createComponentPodWithContainerState(kubeclient, "pod1", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message1, deploymentModels.Failing, true)
+	createComponentPodWithContainerState(kubeclient, "pod2", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message1, deploymentModels.Failing, true)
 	message2 := "Couldn't find key TEST_SECRET in Secret radix-demo-hello-nodejs-dev/job"
-	createComponentPodWithContainerState(kubeclient, "pod3", builders.GetEnvironmentNamespace(anyAppName, "dev"), "job", message2, deploymentModels.Failing, true)
+	createComponentPodWithContainerState(kubeclient, "pod3", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "job", message2, deploymentModels.Failing, true)
 
 	endpoint := createGetComponentsEndpoint(anyAppName, anyDeployName)
 
@@ -415,20 +414,20 @@ func TestGetComponents_ReplicaStatus_Failing(t *testing.T) {
 func TestGetComponents_ReplicaStatus_Running(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, kubeclient, _, _, _ := setupTest()
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName(anyDeployName).
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app")).
+			operatorUtils.NewDeployComponentBuilder().WithName("app")).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job")))
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job")))
 
 	message := ""
-	createComponentPodWithContainerState(kubeclient, "pod1", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, true)
-	createComponentPodWithContainerState(kubeclient, "pod2", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, true)
-	createComponentPodWithContainerState(kubeclient, "pod3", builders.GetEnvironmentNamespace(anyAppName, "dev"), "job", message, deploymentModels.Running, true)
+	createComponentPodWithContainerState(kubeclient, "pod1", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, true)
+	createComponentPodWithContainerState(kubeclient, "pod2", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, true)
+	createComponentPodWithContainerState(kubeclient, "pod3", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "job", message, deploymentModels.Running, true)
 
 	endpoint := createGetComponentsEndpoint(anyAppName, anyDeployName)
 
@@ -455,20 +454,20 @@ func TestGetComponents_ReplicaStatus_Running(t *testing.T) {
 func TestGetComponents_ReplicaStatus_Starting(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, kubeclient, _, _, _ := setupTest()
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName(anyDeployName).
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app")).
+			operatorUtils.NewDeployComponentBuilder().WithName("app")).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job")))
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job")))
 
 	message := ""
-	createComponentPodWithContainerState(kubeclient, "pod1", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, false)
-	createComponentPodWithContainerState(kubeclient, "pod2", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, false)
-	createComponentPodWithContainerState(kubeclient, "pod3", builders.GetEnvironmentNamespace(anyAppName, "dev"), "job", message, deploymentModels.Running, false)
+	createComponentPodWithContainerState(kubeclient, "pod1", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, false)
+	createComponentPodWithContainerState(kubeclient, "pod2", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Running, false)
+	createComponentPodWithContainerState(kubeclient, "pod3", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "job", message, deploymentModels.Running, false)
 
 	endpoint := createGetComponentsEndpoint(anyAppName, anyDeployName)
 
@@ -495,20 +494,20 @@ func TestGetComponents_ReplicaStatus_Starting(t *testing.T) {
 func TestGetComponents_ReplicaStatus_Pending(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, kubeclient, _, _, _ := setupTest()
-	commonTestUtils.ApplyDeployment(builders.
+	commonTestUtils.ApplyDeployment(operatorUtils.
 		ARadixDeployment().
 		WithAppName(anyAppName).
 		WithEnvironment("dev").
 		WithDeploymentName(anyDeployName).
 		WithComponents(
-			builders.NewDeployComponentBuilder().WithName("app")).
+			operatorUtils.NewDeployComponentBuilder().WithName("app")).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().WithName("job")))
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job")))
 
 	message := ""
-	createComponentPodWithContainerState(kubeclient, "pod1", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Pending, true)
-	createComponentPodWithContainerState(kubeclient, "pod2", builders.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Pending, true)
-	createComponentPodWithContainerState(kubeclient, "pod3", builders.GetEnvironmentNamespace(anyAppName, "dev"), "job", message, deploymentModels.Pending, true)
+	createComponentPodWithContainerState(kubeclient, "pod1", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Pending, true)
+	createComponentPodWithContainerState(kubeclient, "pod2", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "app", message, deploymentModels.Pending, true)
+	createComponentPodWithContainerState(kubeclient, "pod3", operatorUtils.GetEnvironmentNamespace(anyAppName, "dev"), "job", message, deploymentModels.Pending, true)
 
 	endpoint := createGetComponentsEndpoint(anyAppName, anyDeployName)
 
@@ -537,13 +536,13 @@ func TestGetComponents_WithHorizontalScaling(t *testing.T) {
 	commonTestUtils, controllerTestUtils, client, radixclient, promclient, secretProviderClient := setupTest()
 	minReplicas := int32(2)
 	maxReplicas := int32(6)
-	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, builders.ARadixDeployment().
+	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, operatorUtils.ARadixDeployment().
 		WithAppName("any-app").
 		WithEnvironment("prod").
 		WithDeploymentName(anyDeployName).
 		WithJobComponents().
 		WithComponents(
-			builders.NewDeployComponentBuilder().
+			operatorUtils.NewDeployComponentBuilder().
 				WithName("frontend").
 				WithPort("http", 8080).
 				WithPublicPort("http").
@@ -571,21 +570,21 @@ func TestGetComponents_WithIdentity(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, client, radixclient, promclient, secretProviderClient := setupTest()
 
-	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, builders.ARadixDeployment().
+	utils.ApplyDeploymentWithSync(client, radixclient, promclient, commonTestUtils, secretProviderClient, operatorUtils.ARadixDeployment().
 		WithAppName("any-app").
 		WithEnvironment("prod").
 		WithDeploymentName(anyDeployName).
 		WithJobComponents(
-			builders.NewDeployJobComponentBuilder().
+			operatorUtils.NewDeployJobComponentBuilder().
 				WithName("job1").
 				WithIdentity(&v1.Identity{Azure: &v1.AzureIdentity{ClientId: "job-clientid"}}),
-			builders.NewDeployJobComponentBuilder().WithName("job2"),
+			operatorUtils.NewDeployJobComponentBuilder().WithName("job2"),
 		).
 		WithComponents(
-			builders.NewDeployComponentBuilder().
+			operatorUtils.NewDeployComponentBuilder().
 				WithName("comp1").
 				WithIdentity(&v1.Identity{Azure: &v1.AzureIdentity{ClientId: "comp-clientid"}}),
-			builders.NewDeployComponentBuilder().WithName("comp2"),
+			operatorUtils.NewDeployComponentBuilder().WithName("comp2"),
 		))
 
 	// Test

--- a/api/deployments/component_controller_test.go
+++ b/api/deployments/component_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	builders "github.com/equinor/radix-operator/pkg/apis/utils"
+	operatorUtils "github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -598,9 +599,9 @@ func TestGetComponents_WithIdentity(t *testing.T) {
 	var components []deploymentModels.Component
 	controllertest.GetResponseBody(response, &components)
 
-	assert.Equal(t, &deploymentModels.Identity{Azure: &deploymentModels.AzureIdentity{ClientId: "job-clientid"}}, getComponentByName("job1", components).Identity)
+	assert.Equal(t, &deploymentModels.Identity{Azure: &deploymentModels.AzureIdentity{ClientId: "job-clientid", ServiceAccountName: operatorUtils.GetComponentServiceAccountName("job1")}}, getComponentByName("job1", components).Identity)
 	assert.Nil(t, getComponentByName("job2", components).Identity)
-	assert.Equal(t, &deploymentModels.Identity{Azure: &deploymentModels.AzureIdentity{ClientId: "comp-clientid"}}, getComponentByName("comp1", components).Identity)
+	assert.Equal(t, &deploymentModels.Identity{Azure: &deploymentModels.AzureIdentity{ClientId: "comp-clientid", ServiceAccountName: operatorUtils.GetComponentServiceAccountName("comp1")}}, getComponentByName("comp1", components).Identity)
 	assert.Nil(t, getComponentByName("comp2", components).Identity)
 }
 

--- a/api/deployments/deployment_handler.go
+++ b/api/deployments/deployment_handler.go
@@ -10,6 +10,7 @@ import (
 	deploymentModels "github.com/equinor/radix-api/api/deployments/models"
 	"github.com/equinor/radix-api/api/pods"
 	"github.com/equinor/radix-api/models"
+	"github.com/equinor/radix-common/utils/slice"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	operatorUtils "github.com/equinor/radix-operator/pkg/apis/utils"

--- a/api/deployments/deployment_handler.go
+++ b/api/deployments/deployment_handler.go
@@ -10,7 +10,6 @@ import (
 	deploymentModels "github.com/equinor/radix-api/api/deployments/models"
 	"github.com/equinor/radix-api/api/pods"
 	"github.com/equinor/radix-api/models"
-	radixutils "github.com/equinor/radix-common/utils"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	operatorUtils "github.com/equinor/radix-operator/pkg/apis/utils"
@@ -134,14 +133,6 @@ func (deploy *deployHandler) GetDeploymentWithName(appName, deploymentName strin
 		return nil, err
 	}
 
-	var activeTo time.Time
-	if !strings.EqualFold(deploymentSummary.ActiveTo, "") {
-		activeTo, err = radixutils.ParseTimestamp(deploymentSummary.ActiveTo)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	components, err := deploy.GetComponentsForDeployment(appName, deploymentSummary)
 	if err != nil {
 		return nil, err
@@ -154,8 +145,7 @@ func (deploy *deployHandler) GetDeploymentWithName(appName, deploymentName strin
 	}
 
 	dep, _ := deploymentModels.NewDeploymentBuilder().
-		WithRadixDeployment(*rd).
-		WithActiveTo(activeTo).
+		WithRadixDeployment(rd).
 		WithComponents(components).
 		WithGitCommitHash(rd.Annotations[kube.RadixCommitAnnotation]).
 		WithGitTags(rd.Annotations[kube.RadixGitTagsAnnotation]).
@@ -247,7 +237,7 @@ func (deploy *deployHandler) getDeployments(namespace, appName, jobName string, 
 
 		deploySummary, err := deploymentModels.
 			NewDeploymentBuilder().
-			WithRadixDeployment(rd).
+			WithRadixDeployment(&rd).
 			WithPipelineJob(radixJobMap[rd.Labels[kube.RadixJobNameLabel]]).
 			WithRadixRegistration(rr).
 			BuildDeploymentSummary()

--- a/api/deployments/models/component_builder.go
+++ b/api/deployments/models/component_builder.go
@@ -151,6 +151,7 @@ func (b *componentBuilder) WithComponent(component v1.RadixCommonDeployComponent
 		if azure := identity.Azure; azure != nil {
 			b.identity.Azure = &AzureIdentity{}
 			b.identity.Azure.ClientId = azure.ClientId
+			b.identity.Azure.ServiceAccountName = utils.GetComponentServiceAccountName(component.GetName())
 		}
 	}
 

--- a/api/deployments/models/component_builder.go
+++ b/api/deployments/models/component_builder.go
@@ -38,6 +38,7 @@ type componentBuilder struct {
 	schedulerPort             *int32
 	scheduledJobPayloadPath   string
 	auxResource               AuxiliaryResource
+	identity                  *Identity
 	errors                    []error
 }
 
@@ -145,6 +146,14 @@ func (b *componentBuilder) WithComponent(component v1.RadixCommonDeployComponent
 		}
 	}
 
+	if identity := component.GetIdentity(); identity != nil {
+		b.identity = &Identity{}
+		if azure := identity.Azure; azure != nil {
+			b.identity.Azure = &AzureIdentity{}
+			b.identity.Azure.ClientId = azure.ClientId
+		}
+	}
+
 	b.environmentVariables = component.GetEnvironmentVariables()
 	return b
 }
@@ -188,6 +197,7 @@ func (b *componentBuilder) BuildComponent() (*Component, error) {
 		SchedulerPort:           b.schedulerPort,
 		ScheduledJobPayloadPath: b.scheduledJobPayloadPath,
 		AuxiliaryResource:       b.auxResource,
+		Identity:                b.identity,
 	}, b.buildError()
 }
 

--- a/api/deployments/models/component_deployment.go
+++ b/api/deployments/models/component_deployment.go
@@ -88,7 +88,29 @@ type Component struct {
 	// required: false
 	HorizontalScalingSummary *HorizontalScalingSummary `json:"horizontalScalingSummary"`
 
+	// External identity information
+	//
+	// required: false
+	Identity *Identity `json:"identity,omitempty"`
+
 	AuxiliaryResource `json:",inline"`
+}
+
+// Identity describes external identities
+type Identity struct {
+	// Azure identity
+	//
+	// required: false
+	Azure *AzureIdentity `json:"azure,omitempty"`
+}
+
+// AzureIdentity describes an identity in Azure
+type AzureIdentity struct {
+	// ClientId is the client ID of an Azure User Assigned Managed Identity
+	// or the application ID of an Azure AD Application Registration
+	//
+	// required: true
+	ClientId string `json:"clientId,omitempty"`
 }
 
 // AuxiliaryResource describes an auxiliary resources for a component

--- a/api/deployments/models/component_deployment.go
+++ b/api/deployments/models/component_deployment.go
@@ -111,6 +111,11 @@ type AzureIdentity struct {
 	//
 	// required: true
 	ClientId string `json:"clientId,omitempty"`
+
+	// The Service Account name to use when configuring Kubernetes Federation Credentials for the identity
+	//
+	// required: true
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // AuxiliaryResource describes an auxiliary resources for a component

--- a/api/deployments/models/deployment.go
+++ b/api/deployments/models/deployment.go
@@ -9,6 +9,12 @@ type Deployment struct {
 	// example: radix-canary-golang-tzbqi
 	Name string `json:"name"`
 
+	// Namespace where the deployment is stored
+	//
+	// required: true
+	// example: radix-canary-golang-dev
+	Namespace string `json:"namespace"`
+
 	// Array of components
 	//
 	// required: false

--- a/api/deployments/models/deployment_builder_test.go
+++ b/api/deployments/models/deployment_builder_test.go
@@ -22,7 +22,7 @@ func Test_DeploymentBuilder_BuildDeploymentSummary(t *testing.T) {
 		t.Parallel()
 
 		b := NewDeploymentBuilder().WithRadixDeployment(
-			v1.RadixDeployment{
+			&v1.RadixDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   deploymentName,
 					Labels: map[string]string{kube.RadixJobNameLabel: jobName},
@@ -98,8 +98,8 @@ func Test_DeploymentBuilder_BuildDeploymentSummary(t *testing.T) {
 }
 
 func Test_DeploymentBuilder_BuildDeployment(t *testing.T) {
-	appName, deploymentName, envName, jobName, activeFrom, activeTo, cloneUrl, repoUrl :=
-		"app-name", "deployment-name", "env-name", "job-name", time.Now().Add(-10*time.Second).Truncate(1*time.Second),
+	appName, deploymentName, deploymentNamespace, envName, jobName, activeFrom, activeTo, cloneUrl, repoUrl :=
+		"app-name", "deployment-name", "deployment-namespace", "env-name", "job-name", time.Now().Add(-10*time.Second).Truncate(1*time.Second),
 		time.Now().Truncate(1*time.Second), "git@github.com:equinor/radix-canary-golang.git",
 		"https://github.com/equinor/radix-canary-golang"
 
@@ -112,10 +112,11 @@ func Test_DeploymentBuilder_BuildDeployment(t *testing.T) {
 		t.Parallel()
 
 		b := NewDeploymentBuilder().WithRadixDeployment(
-			v1.RadixDeployment{
+			&v1.RadixDeployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   deploymentName,
-					Labels: map[string]string{kube.RadixJobNameLabel: jobName},
+					Name:      deploymentName,
+					Namespace: deploymentNamespace,
+					Labels:    map[string]string{kube.RadixJobNameLabel: jobName},
 				},
 				Spec: v1.RadixDeploymentSpec{
 					Environment: envName,
@@ -131,6 +132,7 @@ func Test_DeploymentBuilder_BuildDeployment(t *testing.T) {
 		assert.NoError(t, err)
 		expected := &Deployment{
 			Name:         deploymentName,
+			Namespace:    deploymentNamespace,
 			CreatedByJob: jobName,
 			Environment:  envName,
 			ActiveFrom:   radixutils.FormatTimestamp(activeFrom),


### PR DESCRIPTION
Include information about identity federation (identity clientid, service account name and namespace)
Removed public methods (made them private) from DeploymentBuilder that was not used outside of the builder itself.