### PR TITLE
fix memory leak in radix-api

### DIFF
--- a/api/environments/environment_handler.go
+++ b/api/environments/environment_handler.go
@@ -66,8 +66,13 @@ type EnvironmentHandlerFactory func(accounts models.Accounts) EnvironmentHandler
 
 func NewEnvironmentHandlerFactory(opts ...EnvironmentHandlerOptions) EnvironmentHandlerFactory {
 	return func(accounts models.Accounts) EnvironmentHandler {
-		opts = append(opts, WithAccounts(accounts))
-		return Init(opts...)
+		// We must make a new slice and copy values from opts into it.
+		// Appending to the original opts will modify its underlying array and cause a memory leak.
+		newOpts := make([]EnvironmentHandlerOptions, len(opts), len(opts)+1)
+		copy(newOpts, opts)
+		newOpts = append(newOpts, WithAccounts(accounts))
+		eh := Init(newOpts...)
+		return eh
 	}
 }
 


### PR DESCRIPTION
Fixed the memory leak by creating a new slice (newOpts) which we copy the original values from (opts).

The bug was caused by appending to the original slice, and thereby the original underlying array. This array is created in the main() method and will never be dereferenced, and therefore never GCed