### PR TITLE
Release Allow API to manage AD Users and Reader AD Users (#677)

### DIFF
--- a/api/applications/applications_handler.go
+++ b/api/applications/applications_handler.go
@@ -283,9 +283,19 @@ func (ah *ApplicationHandler) ModifyRegistrationDetails(ctx context.Context, app
 		payload = append(payload, patch{Op: "replace", Path: "/spec/adGroups", Value: *patchRequest.AdGroups})
 		runUpdate = true
 	}
+	if patchRequest.AdUsers != nil && !radixutils.ArrayEqualElements(currentRegistration.Spec.AdUsers, *patchRequest.AdUsers) {
+		updatedRegistration.Spec.AdUsers = *patchRequest.AdUsers
+		payload = append(payload, patch{Op: "replace", Path: "/spec/adUsers", Value: *patchRequest.AdUsers})
+		runUpdate = true
+	}
 	if patchRequest.ReaderAdGroups != nil && !radixutils.ArrayEqualElements(currentRegistration.Spec.ReaderAdGroups, *patchRequest.ReaderAdGroups) {
 		updatedRegistration.Spec.ReaderAdGroups = *patchRequest.ReaderAdGroups
 		payload = append(payload, patch{Op: "replace", Path: "/spec/readerAdGroups", Value: *patchRequest.ReaderAdGroups})
+		runUpdate = true
+	}
+	if patchRequest.ReaderAdUsers != nil && !radixutils.ArrayEqualElements(currentRegistration.Spec.ReaderAdUsers, *patchRequest.ReaderAdUsers) {
+		updatedRegistration.Spec.ReaderAdUsers = *patchRequest.ReaderAdUsers
+		payload = append(payload, patch{Op: "replace", Path: "/spec/readerAdUsers", Value: *patchRequest.ReaderAdUsers})
 		runUpdate = true
 	}
 

--- a/api/applications/models/application_registration.go
+++ b/api/applications/models/application_registration.go
@@ -25,10 +25,20 @@ type ApplicationRegistration struct {
 	// required: true
 	AdGroups []string `json:"adGroups"`
 
+	// AdUsers the users/service-principals that should be able to access the application
+	//
+	// required: true
+	AdUsers []string `json:"adUsers"`
+
 	// ReaderAdGroups the groups that should be able to read the application
 	//
-	// required: false
+	// required: true
 	ReaderAdGroups []string `json:"readerAdGroups"`
+
+	// ReaderAdUsers the users/service-principals that should be able to read the application
+	//
+	// required: true
+	ReaderAdUsers []string `json:"readerAdUsers"`
 
 	// Owner of the application (email). Can be a single person or a shared group email
 	//

--- a/api/applications/models/application_registration_builder.go
+++ b/api/applications/models/application_registration_builder.go
@@ -13,7 +13,9 @@ type ApplicationRegistrationBuilder interface {
 	WithRepository(string) ApplicationRegistrationBuilder
 	WithSharedSecret(string) ApplicationRegistrationBuilder
 	WithAdGroups([]string) ApplicationRegistrationBuilder
+	WithAdUsers([]string) ApplicationRegistrationBuilder
 	WithReaderAdGroups([]string) ApplicationRegistrationBuilder
+	WithReaderAdUsers([]string) ApplicationRegistrationBuilder
 	WithCloneURL(string) ApplicationRegistrationBuilder
 	WithWBS(string) ApplicationRegistrationBuilder
 	WithConfigBranch(string) ApplicationRegistrationBuilder
@@ -38,6 +40,8 @@ type applicationBuilder struct {
 	configBranch        string
 	configurationItem   string
 	radixConfigFullName string
+	adUsers             []string
+	readerAdUsers       []string
 }
 
 func (rb *applicationBuilder) WithAppRegistration(appRegistration *ApplicationRegistration) ApplicationRegistrationBuilder {
@@ -45,7 +49,9 @@ func (rb *applicationBuilder) WithAppRegistration(appRegistration *ApplicationRe
 	rb.WithRepository(appRegistration.Repository)
 	rb.WithSharedSecret(appRegistration.SharedSecret)
 	rb.WithAdGroups(appRegistration.AdGroups)
+	rb.WithAdUsers(appRegistration.AdUsers)
 	rb.WithReaderAdGroups(appRegistration.ReaderAdGroups)
+	rb.WithReaderAdUsers(appRegistration.ReaderAdUsers)
 	rb.WithOwner(appRegistration.Owner)
 	rb.WithWBS(appRegistration.WBS)
 	rb.WithConfigBranch(appRegistration.ConfigBranch)
@@ -59,7 +65,9 @@ func (rb *applicationBuilder) WithRadixRegistration(radixRegistration *v1.RadixR
 	rb.WithCloneURL(radixRegistration.Spec.CloneURL)
 	rb.WithSharedSecret(radixRegistration.Spec.SharedSecret)
 	rb.WithAdGroups(radixRegistration.Spec.AdGroups)
+	rb.WithAdUsers(radixRegistration.Spec.AdUsers)
 	rb.WithReaderAdGroups(radixRegistration.Spec.ReaderAdGroups)
+	rb.WithReaderAdUsers(radixRegistration.Spec.ReaderAdUsers)
 	rb.WithOwner(radixRegistration.Spec.Owner)
 	rb.WithCreator(radixRegistration.Spec.Creator)
 	rb.WithWBS(radixRegistration.Spec.WBS)
@@ -106,8 +114,18 @@ func (rb *applicationBuilder) WithAdGroups(adGroups []string) ApplicationRegistr
 	return rb
 }
 
+func (rb *applicationBuilder) WithAdUsers(adUsers []string) ApplicationRegistrationBuilder {
+	rb.adUsers = adUsers
+	return rb
+}
+
 func (rb *applicationBuilder) WithReaderAdGroups(readerAdGroups []string) ApplicationRegistrationBuilder {
 	rb.readerAdGroups = readerAdGroups
+	return rb
+}
+
+func (rb *applicationBuilder) WithReaderAdUsers(readerAdUsers []string) ApplicationRegistrationBuilder {
+	rb.readerAdUsers = readerAdUsers
 	return rb
 }
 
@@ -142,7 +160,9 @@ func (rb *applicationBuilder) Build() ApplicationRegistration {
 		Repository:          repository,
 		SharedSecret:        rb.sharedSecret,
 		AdGroups:            rb.adGroups,
+		AdUsers:             rb.adUsers,
 		ReaderAdGroups:      rb.readerAdGroups,
+		ReaderAdUsers:       rb.readerAdUsers,
 		Owner:               rb.owner,
 		Creator:             rb.creator,
 		WBS:                 rb.wbs,
@@ -160,7 +180,9 @@ func (rb *applicationBuilder) BuildRR() (*v1.RadixRegistration, error) {
 		WithRepository(rb.repository).
 		WithSharedSecret(rb.sharedSecret).
 		WithAdGroups(rb.adGroups).
+		WithAdUsers(rb.adUsers).
 		WithReaderAdGroups(rb.readerAdGroups).
+		WithReaderAdUsers(rb.readerAdUsers).
 		WithOwner(rb.owner).
 		WithCreator(rb.creator).
 		WithWBS(rb.wbs).

--- a/api/applications/models/application_registration_patch.go
+++ b/api/applications/models/application_registration_patch.go
@@ -8,10 +8,20 @@ type ApplicationRegistrationPatch struct {
 	// required: false
 	AdGroups *[]string `json:"adGroups,omitempty"`
 
+	// AdUsers the users/service-principals that should be able to access the application
+	//
+	// required: false
+	AdUsers *[]string `json:"adUsers,omitempty"`
+
 	// ReaderAdGroups the groups that should be able to read the application
 	//
 	// required: false
 	ReaderAdGroups *[]string `json:"readerAdGroups,omitempty"`
+
+	// ReaderAdUsers the users/service-principals that should be able to read the application
+	//
+	// required: false
+	ReaderAdUsers *[]string `json:"readerAdUsers,omitempty"`
 
 	// Owner of the application - should be an email
 	//

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,12 @@ require (
 	github.com/cert-manager/cert-manager v1.15.0
 	github.com/equinor/radix-common v1.9.5
 	github.com/equinor/radix-job-scheduler v1.11.0
-	github.com/equinor/radix-operator v1.59.1
+	github.com/equinor/radix-operator v1.61.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/kedacore/keda/v2 v2.15.1
 	github.com/marstr/guid v1.1.0
@@ -64,7 +65,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-containerregistry v0.16.1 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/equinor/radix-common v1.9.5 h1:p1xldkYUoavwIMguoxxOyVkOXLPA6K8qMsgzez
 github.com/equinor/radix-common v1.9.5/go.mod h1:+g0Wj0D40zz29DjNkYKVmCVeYy4OsFWKI7Qi9rA6kpY=
 github.com/equinor/radix-job-scheduler v1.11.0 h1:8wCmXOVl/1cto8q2WJQEE06Cw68/QmfoifYVR49vzkY=
 github.com/equinor/radix-job-scheduler v1.11.0/go.mod h1:yPXn3kDcMY0Z3kBkosjuefsdY1x2g0NlBeybMmHz5hc=
-github.com/equinor/radix-operator v1.59.1 h1:wzb2tF4MWtGDWmyYuIv3oh17G5Bx8ztW9O+WgnI3QFc=
-github.com/equinor/radix-operator v1.59.1/go.mod h1:uRW9SgVZ94hkpq87npVv2YVviRuXNJ1zgCleya1uvr8=
+github.com/equinor/radix-operator v1.61.0 h1:kHWHn5p9S+wKqOTSKtju2URW5FKgAFng1p6RLRnaTmE=
+github.com/equinor/radix-operator v1.61.0/go.mod h1:uRW9SgVZ94hkpq87npVv2YVviRuXNJ1zgCleya1uvr8=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/swaggerui/html/swagger.json
+++ b/swaggerui/html/swagger.json
@@ -5307,6 +5307,9 @@
         "repository",
         "sharedSecret",
         "adGroups",
+        "adUsers",
+        "readerAdGroups",
+        "readerAdUsers",
         "owner",
         "creator",
         "configBranch"
@@ -5319,6 +5322,14 @@
             "type": "string"
           },
           "x-go-name": "AdGroups"
+        },
+        "adUsers": {
+          "description": "AdUsers the users/service-principals that should be able to access the application",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "AdUsers"
         },
         "configBranch": {
           "description": "ConfigBranch information",
@@ -5359,6 +5370,14 @@
           },
           "x-go-name": "ReaderAdGroups"
         },
+        "readerAdUsers": {
+          "description": "ReaderAdUsers the users/service-principals that should be able to read the application",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "ReaderAdUsers"
+        },
         "repository": {
           "description": "Repository the github repository",
           "type": "string",
@@ -5390,6 +5409,14 @@
           },
           "x-go-name": "AdGroups"
         },
+        "adUsers": {
+          "description": "AdUsers the users/service-principals that should be able to access the application",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "AdUsers"
+        },
         "configBranch": {
           "description": "ConfigBranch information",
           "type": "string",
@@ -5417,6 +5444,14 @@
             "type": "string"
           },
           "x-go-name": "ReaderAdGroups"
+        },
+        "readerAdUsers": {
+          "description": "ReaderAdUsers the users/service-principals that should be able to read the application",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "ReaderAdUsers"
         },
         "repository": {
           "description": "Repository the github repository",


### PR DESCRIPTION
* Allow API to manage AD Users and Reader AD Users

* Update swagger

* Add test for Getting application, ad users is set

* Update operator

* Update types to imply AdUsers is always set

* update operator