### PR TITLE
Release radix-api

### DIFF
--- a/api/applications/applications_handler.go
+++ b/api/applications/applications_handler.go
@@ -536,6 +536,7 @@ func (ah *ApplicationHandler) triggerPipelineBuildOrBuildDeploy(ctx context.Cont
 	}
 
 	branch := pipelineParameters.Branch
+	envName := pipelineParameters.ToEnvironment
 	commitID := pipelineParameters.CommitID
 
 	if strings.TrimSpace(appName) == "" || strings.TrimSpace(branch) == "" {
@@ -543,7 +544,6 @@ func (ah *ApplicationHandler) triggerPipelineBuildOrBuildDeploy(ctx context.Cont
 	}
 
 	log.Ctx(ctx).Info().Msgf("Creating build pipeline jobController for %s on branch %s for commit %s", appName, branch, commitID)
-
 	radixRegistration, err := ah.getUserAccount().RadixClient.RadixV1().RadixRegistrations().Get(ctx, appName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -559,6 +559,10 @@ func (ah *ApplicationHandler) triggerPipelineBuildOrBuildDeploy(ctx context.Cont
 		if len(targetEnvironments) == 0 {
 			return nil, applicationModels.UnmatchedBranchToEnvironment(branch)
 		}
+
+		if len(envName) > 0 && !slice.Any(targetEnvironments, func(targetEnvName string) bool { return targetEnvName == envName }) {
+			return nil, applicationModels.EnvironmentNotMappedToBranch(envName, branch)
+		}
 	}
 
 	jobParameters := pipelineParameters.MapPipelineParametersBuildToJobParameter()
@@ -568,7 +572,8 @@ func (ah *ApplicationHandler) triggerPipelineBuildOrBuildDeploy(ctx context.Cont
 		return nil, err
 	}
 
-	log.Ctx(ctx).Info().Msgf("Creating build pipeline job for %s on branch %s for commit %s", appName, branch, commitID)
+	log.Ctx(ctx).Info().Msgf("Creating build pipeline job for %s on branch %s for commit %s%s", appName, branch, commitID,
+		radixutils.TernaryString(len(envName) > 0, fmt.Sprintf(", for environment %s", envName), ""))
 
 	jobSummary, err := HandleStartPipelineJob(ctx, ah.accounts.UserAccount.RadixClient, appName, ah.pipelineImageTag, ah.tektonImageTag, pipeline, jobParameters)
 	if err != nil {

--- a/api/applications/models/application_errors.go
+++ b/api/applications/models/application_errors.go
@@ -11,9 +11,14 @@ func AppNameAndBranchAreRequiredForStartingPipeline() error {
 	return radixhttp.ValidationError("Radix Application Pipeline", "App name and branch are required")
 }
 
-// UnmatchedBranchToEnvironment Triggering a pipeline on a un-mapped branch is not allowed
+// UnmatchedBranchToEnvironment Triggering a pipeline on an un-mapped branch is not allowed
 func UnmatchedBranchToEnvironment(branch string) error {
 	return radixhttp.ValidationError("Radix Application Pipeline", fmt.Sprintf("Failed to match environment to branch: %s", branch))
+}
+
+// EnvironmentNotMappedToBranch Triggering a pipeline on an environment, not matched to a branch
+func EnvironmentNotMappedToBranch(envName, branch string) error {
+	return radixhttp.ValidationError("Radix Application Pipeline", fmt.Sprintf("Failed to match environment %s to branch: %s", envName, branch))
 }
 
 // UserNotAllowedToTriggerPipelineError Triggering a pipeline is not allowed for this user and app

--- a/api/applications/models/pipeline_parameters.go
+++ b/api/applications/models/pipeline_parameters.go
@@ -92,6 +92,13 @@ type PipelineParametersBuild struct {
 	// Extensions:
 	// x-nullable: true
 	OverrideUseBuildCache *bool `json:"overrideUseBuildCache,omitempty"`
+
+	// DeployExternalDNS deploy external DNS
+	//
+	// required: false
+	// Extensions:
+	// x-nullable: true
+	DeployExternalDNS *bool `json:"deployExternalDNS,omitempty"`
 }
 
 // MapPipelineParametersBuildToJobParameter maps to JobParameter
@@ -164,11 +171,19 @@ type PipelineParametersApplyConfig struct {
 	//
 	// example: a_user@equinor.com
 	TriggeredBy string `json:"triggeredBy,omitempty"`
+
+	// DeployExternalDNS deploy external DNS
+	//
+	// required: false
+	// Extensions:
+	// x-nullable: true
+	DeployExternalDNS *bool `json:"deployExternalDNS,omitempty"`
 }
 
 // MapPipelineParametersApplyConfigToJobParameter maps to JobParameter
 func (param PipelineParametersApplyConfig) MapPipelineParametersApplyConfigToJobParameter() *jobModels.JobParameters {
 	return &jobModels.JobParameters{
-		TriggeredBy: param.TriggeredBy,
+		TriggeredBy:       param.TriggeredBy,
+		DeployExternalDNS: param.DeployExternalDNS,
 	}
 }

--- a/api/applications/models/pipeline_parameters.go
+++ b/api/applications/models/pipeline_parameters.go
@@ -50,6 +50,11 @@ type PipelineParametersBuild struct {
 	// example: master
 	Branch string `json:"branch"`
 
+	// Name of environment to build for
+	//
+	// example: prod
+	ToEnvironment string `json:"toEnvironment,omitempty"`
+
 	// CommitID the commit ID of the branch to build
 	// REQUIRED for "build" and "build-deploy" pipelines
 	//
@@ -93,6 +98,7 @@ type PipelineParametersBuild struct {
 func (buildParam PipelineParametersBuild) MapPipelineParametersBuildToJobParameter() *jobModels.JobParameters {
 	return &jobModels.JobParameters{
 		Branch:                buildParam.Branch,
+		ToEnvironment:         buildParam.ToEnvironment,
 		CommitID:              buildParam.CommitID,
 		PushImage:             buildParam.PushImageToContainerRegistry(),
 		TriggeredBy:           buildParam.TriggeredBy,

--- a/api/applications/start_job_handler.go
+++ b/api/applications/start_job_handler.go
@@ -62,6 +62,7 @@ func buildPipelineJob(ctx context.Context, appName, cloneURL, radixConfigFullNam
 	var buildSpec v1.RadixBuildSpec
 	var promoteSpec v1.RadixPromoteSpec
 	var deploySpec v1.RadixDeploySpec
+	var applyConfigSpec v1.RadixApplyConfigSpec
 
 	log.Ctx(ctx).Info().Msgf("Using %s pipeline image tag", pipelineImageTag)
 	log.Ctx(ctx).Info().Msgf("Using %s as tekton image tag", tektonImageTag)
@@ -90,6 +91,10 @@ func buildPipelineJob(ctx context.Context, appName, cloneURL, radixConfigFullNam
 			CommitID:           jobSpec.CommitID,
 			ComponentsToDeploy: jobSpec.ComponentsToDeploy,
 		}
+	case v1.ApplyConfig:
+		applyConfigSpec = v1.RadixApplyConfigSpec{
+			DeployExternalDNS: jobSpec.DeployExternalDNS != nil && *jobSpec.DeployExternalDNS,
+		}
 	}
 
 	job := v1.RadixJob{
@@ -105,12 +110,13 @@ func buildPipelineJob(ctx context.Context, appName, cloneURL, radixConfigFullNam
 		Spec: v1.RadixJobSpec{
 			AppName:             appName,
 			CloneURL:            cloneURL,
+			TektonImage:         tektonImageTag,
 			PipeLineType:        pipeline.Type,
 			PipelineImage:       pipelineImageTag,
-			TektonImage:         tektonImageTag,
 			Build:               buildSpec,
 			Promote:             promoteSpec,
 			Deploy:              deploySpec,
+			ApplyConfig:         applyConfigSpec,
 			TriggeredBy:         getTriggeredBy(ctx, jobSpec.TriggeredBy),
 			RadixConfigFullName: fmt.Sprintf("/workspace/%s", radixConfigFullName),
 		},

--- a/api/applications/start_job_handler.go
+++ b/api/applications/start_job_handler.go
@@ -71,6 +71,7 @@ func buildPipelineJob(ctx context.Context, appName, cloneURL, radixConfigFullNam
 		buildSpec = v1.RadixBuildSpec{
 			ImageTag:              imageTag,
 			Branch:                jobSpec.Branch,
+			ToEnvironment:         jobSpec.ToEnvironment,
 			CommitID:              jobSpec.CommitID,
 			PushImage:             jobSpec.PushImage,
 			OverrideUseBuildCache: jobSpec.OverrideUseBuildCache,

--- a/api/defaults/environment_variables.go
+++ b/api/defaults/environment_variables.go
@@ -1,6 +1,0 @@
-package defaults
-
-const (
-	// RadixDNSZoneEnvironmentVariable The environment variable on a radix app giving the dns zone. Will be equal to OperatorDNSZoneEnvironmentVariable
-	RadixDNSZoneEnvironmentVariable = "RADIX_DNS_ZONE"
-)

--- a/api/deployments/models/deployment.go
+++ b/api/deployments/models/deployment.go
@@ -60,6 +60,12 @@ type Deployment struct {
 	// required: true
 	// example: https://github.com/equinor/radix-canary-golang
 	Repository string `json:"repository,omitempty"`
+
+	// Name of the branch used to build the deployment
+	//
+	// required: false
+	// example: main
+	BuiltFromBranch string `json:"builtFromBranch,omitempty"`
 }
 
 func (d *Deployment) GetComponentByName(name string) *Component {

--- a/api/deployments/models/deployment_builder.go
+++ b/api/deployments/models/deployment_builder.go
@@ -46,7 +46,6 @@ func NewDeploymentBuilder() DeploymentBuilder {
 
 func (b *deploymentBuilder) WithRadixDeployment(rd *v1.RadixDeployment) DeploymentBuilder {
 	jobName := rd.Labels[kube.RadixJobNameLabel]
-
 	b.withComponentSummariesFromRadixDeployment(rd).
 		withEnvironment(rd.Spec.Environment).
 		withNamespace(rd.GetNamespace()).

--- a/api/deployments/models/deployment_builder.go
+++ b/api/deployments/models/deployment_builder.go
@@ -191,6 +191,7 @@ func (b *deploymentBuilder) buildDeploySummaryPipelineJobInfo() DeploymentSummar
 	if b.pipelineJob != nil {
 		jobInfo.CommitID = b.pipelineJob.Spec.Build.CommitID
 		jobInfo.PipelineJobType = string(b.pipelineJob.Spec.PipeLineType)
+		jobInfo.BuiltFromBranch = b.pipelineJob.Spec.Build.Branch
 		jobInfo.PromotedFromEnvironment = b.pipelineJob.Spec.Promote.FromEnvironment
 	}
 
@@ -199,7 +200,7 @@ func (b *deploymentBuilder) buildDeploySummaryPipelineJobInfo() DeploymentSummar
 
 func (b *deploymentBuilder) BuildDeployment() (*Deployment, error) {
 	b.setSkipDeploymentForComponents()
-	return &Deployment{
+	deployment := Deployment{
 		Name:          b.name,
 		Namespace:     b.namespace,
 		Environment:   b.environment,
@@ -210,5 +211,9 @@ func (b *deploymentBuilder) BuildDeployment() (*Deployment, error) {
 		GitCommitHash: b.gitCommitHash,
 		GitTags:       b.gitTags,
 		Repository:    b.repository,
-	}, b.buildError()
+	}
+	if b.pipelineJob != nil {
+		deployment.BuiltFromBranch = b.pipelineJob.Spec.Build.Branch
+	}
+	return &deployment, b.buildError()
 }

--- a/api/deployments/models/deployment_builder_test.go
+++ b/api/deployments/models/deployment_builder_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func Test_DeploymentBuilder_BuildDeploymentSummary(t *testing.T) {
-	deploymentName, envName, jobName, commitID, promoteFromEnv, activeFrom, activeTo :=
+	deploymentName, envName, jobName, commitID, promoteFromEnv, activeFrom, activeTo, buildFromBranch :=
 		"deployment-name", "env-name", "job-name", "commit-id", "from-env-name",
-		time.Now().Add(-10*time.Second).Truncate(1*time.Second), time.Now().Truncate(1*time.Second)
+		time.Now().Add(-10*time.Second).Truncate(1*time.Second), time.Now().Truncate(1*time.Second), "anybranch"
 
 	t.Run("build with deployment", func(t *testing.T) {
 		t.Parallel()
@@ -81,6 +81,7 @@ func Test_DeploymentBuilder_BuildDeploymentSummary(t *testing.T) {
 					PipeLineType: radixv1.BuildDeploy,
 					Build: radixv1.RadixBuildSpec{
 						CommitID: commitID,
+						Branch:   buildFromBranch,
 					},
 					Promote: radixv1.RadixPromoteSpec{
 						FromEnvironment: promoteFromEnv,
@@ -96,6 +97,7 @@ func Test_DeploymentBuilder_BuildDeploymentSummary(t *testing.T) {
 				CommitID:                commitID,
 				PipelineJobType:         string(radixv1.BuildDeploy),
 				PromotedFromEnvironment: promoteFromEnv,
+				BuiltFromBranch:         buildFromBranch,
 			},
 		}
 		assert.Equal(t, expected, actual)

--- a/api/deployments/models/deployment_summary.go
+++ b/api/deployments/models/deployment_summary.go
@@ -9,7 +9,7 @@ type DeploymentSummaryPipelineJobInfo struct {
 	// Type of pipeline job
 	//
 	// required: false
-	// enum: build,build-deploy,promote,deploy
+	// enum: build,build-deploy,promote,deploy,apply-config
 	// example: build-deploy
 	PipelineJobType string `json:"pipelineJobType,omitempty"`
 

--- a/api/deployments/models/deployment_summary.go
+++ b/api/deployments/models/deployment_summary.go
@@ -13,6 +13,12 @@ type DeploymentSummaryPipelineJobInfo struct {
 	// example: build-deploy
 	PipelineJobType string `json:"pipelineJobType,omitempty"`
 
+	// Name of the branch used to build the deployment
+	//
+	// required: false
+	// example: main
+	BuiltFromBranch string `json:"builtFromBranch,omitempty"`
+
 	// Name of the environment the deployment was promoted from
 	// Applies only for pipeline jobs of type 'promote'
 	//

--- a/api/environmentvariables/env_vars_controller_test.go
+++ b/api/environmentvariables/env_vars_controller_test.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	clusterName     = "AnyClusterName"
+	clusterType     = "development"
 	appName         = "any-app"
 	environmentName = "dev"
 	componentName   = "backend"

--- a/api/environmentvariables/env_vars_handler.go
+++ b/api/environmentvariables/env_vars_handler.go
@@ -6,14 +6,15 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/equinor/radix-operator/pkg/apis/deployment"
-	"github.com/rs/zerolog/log"
-
 	envvarsmodels "github.com/equinor/radix-api/api/environmentvariables/models"
 	"github.com/equinor/radix-api/models"
+	"github.com/equinor/radix-common/utils/slice"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	crdUtils "github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/rs/zerolog/log"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -68,7 +69,7 @@ func (eh *envVarsHandler) GetComponentEnvVars(ctx context.Context, appName strin
 	if err != nil {
 		return nil, err
 	}
-	envVars, err := deployment.GetEnvironmentVariables(ctx, eh.kubeUtil, appName, rd, radixDeployComponent)
+	envVars, err := eh.getDeploymentEnvironmentVariables(ctx, appName, rd.Spec.Environment, radixDeployComponent)
 	if err != nil {
 		return nil, err
 	}
@@ -162,6 +163,20 @@ func (eh *envVarsHandler) ChangeEnvVar(ctx context.Context, appName, envName, co
 		return err
 	}
 	return eh.kubeUtil.ApplyEnvVarsMetadataConfigMap(ctx, namespace, envVarsMetadataConfigMap, envVarsMetadataMap)
+}
+
+func (eh *envVarsHandler) getDeploymentEnvironmentVariables(ctx context.Context, appName, envName string, radixDeployComponent v1.RadixCommonDeployComponent) ([]corev1.EnvVar, error) {
+	deployment, err := eh.accounts.UserAccount.Client.AppsV1().Deployments(crdUtils.GetEnvironmentNamespace(appName, envName)).Get(ctx, radixDeployComponent.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	componentContainer, ok := slice.FindFirst(deployment.Spec.Template.Spec.Containers, func(container corev1.Container) bool { return container.Name == radixDeployComponent.GetName() })
+	if !ok {
+		return nil, fmt.Errorf("container %s not found in deployment", radixDeployComponent.GetName())
+	}
+	return slice.FindAll(componentContainer.Env, func(envVar corev1.EnvVar) bool {
+		return envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil
+	}), nil
 }
 
 func getComponent(rd *v1.RadixDeployment, componentName string) v1.RadixCommonDeployComponent {

--- a/api/jobs/models/job.go
+++ b/api/jobs/models/job.go
@@ -6,6 +6,7 @@ import (
 
 	deploymentModels "github.com/equinor/radix-api/api/deployments/models"
 	radixutils "github.com/equinor/radix-common/utils"
+	"github.com/equinor/radix-common/utils/pointers"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
@@ -80,7 +81,7 @@ type Job struct {
 	// Name of the pipeline
 	//
 	// required: false
-	// enum: build,build-deploy,promote,deploy
+	// enum: build,build-deploy,promote,deploy,apply-config
 	// example: build-deploy
 	Pipeline string `json:"pipeline"`
 
@@ -132,6 +133,20 @@ type Job struct {
 	// items:
 	//    "$ref": "#/definitions/ComponentSummary"
 	Components []*deploymentModels.ComponentSummary `json:"components,omitempty"`
+
+	// OverrideUseBuildCache override default or configured build cache option
+	//
+	// required: false
+	// Extensions:
+	// x-nullable: true
+	OverrideUseBuildCache *bool `json:"overrideUseBuildCache,omitempty"`
+
+	// DeployExternalDNS deploy external DNS
+	//
+	// required: false
+	// Extensions:
+	// x-nullable: true
+	DeployExternalDNS *bool `json:"deployExternalDNS,omitempty"`
 }
 
 // GetJobFromRadixJob Gets job from a radix job
@@ -168,6 +183,7 @@ func GetJobFromRadixJob(job *radixv1.RadixJob, jobDeployments []*deploymentModel
 		jobModel.Branch = job.Spec.Build.Branch
 		jobModel.DeployedToEnvironment = job.Spec.Build.ToEnvironment
 		jobModel.CommitID = job.Spec.Build.CommitID
+		jobModel.OverrideUseBuildCache = job.Spec.Build.OverrideUseBuildCache
 	case radixv1.Deploy:
 		jobModel.ImageTagNames = job.Spec.Deploy.ImageTagNames
 		jobModel.DeployedToEnvironment = job.Spec.Deploy.ToEnvironment
@@ -177,6 +193,8 @@ func GetJobFromRadixJob(job *radixv1.RadixJob, jobDeployments []*deploymentModel
 		jobModel.PromotedFromEnvironment = job.Spec.Promote.FromEnvironment
 		jobModel.PromotedToEnvironment = job.Spec.Promote.ToEnvironment
 		jobModel.CommitID = job.Spec.Promote.CommitID
+	case radixv1.ApplyConfig:
+		jobModel.DeployExternalDNS = pointers.Ptr(job.Spec.ApplyConfig.DeployExternalDNS)
 	}
 	return &jobModel
 }

--- a/api/jobs/models/job.go
+++ b/api/jobs/models/job.go
@@ -101,6 +101,12 @@ type Job struct {
 	// example: qa
 	PromotedToEnvironment string `json:"promotedToEnvironment,omitempty"`
 
+	// DeployedToEnvironment the name of the environment that was deployed to
+	//
+	// required: false
+	// example: qa
+	DeployedToEnvironment string `json:"deployedToEnvironment,omitempty"`
+
 	// Array of steps
 	//
 	// required: false
@@ -160,9 +166,11 @@ func GetJobFromRadixJob(job *radixv1.RadixJob, jobDeployments []*deploymentModel
 	switch job.Spec.PipeLineType {
 	case radixv1.Build, radixv1.BuildDeploy:
 		jobModel.Branch = job.Spec.Build.Branch
+		jobModel.DeployedToEnvironment = job.Spec.Build.ToEnvironment
 		jobModel.CommitID = job.Spec.Build.CommitID
 	case radixv1.Deploy:
 		jobModel.ImageTagNames = job.Spec.Deploy.ImageTagNames
+		jobModel.DeployedToEnvironment = job.Spec.Deploy.ToEnvironment
 		jobModel.CommitID = job.Spec.Deploy.CommitID
 	case radixv1.Promote:
 		jobModel.PromotedFromDeployment = job.Spec.Promote.DeploymentName

--- a/api/jobs/models/job_parameters.go
+++ b/api/jobs/models/job_parameters.go
@@ -50,6 +50,13 @@ type JobParameters struct {
 	// Extensions:
 	// x-nullable: true
 	OverrideUseBuildCache *bool `json:"overrideUseBuildCache,omitempty"`
+
+	// DeployExternalDNS deploy external DNS
+	//
+	// required: false
+	// Extensions:
+	// x-nullable: true
+	DeployExternalDNS *bool `json:"deployExternalDNS,omitempty"`
 }
 
 // GetPushImageTag Represents boolean as 1 or 0

--- a/api/jobs/models/job_parameters.go
+++ b/api/jobs/models/job_parameters.go
@@ -21,7 +21,7 @@ type JobParameters struct {
 	// For promote pipeline: Environment to locate deployment to promote
 	FromEnvironment string `json:"fromEnvironment"`
 
-	// For promote pipeline: Target environment for promotion
+	// For build or promote pipeline: Target environment for building and promotion
 	ToEnvironment string `json:"toEnvironment"`
 
 	// ImageRepository of the component, without image name and image-tag

--- a/api/jobs/models/job_summary.go
+++ b/api/jobs/models/job_summary.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	radixutils "github.com/equinor/radix-common/utils"
+	"github.com/equinor/radix-common/utils/pointers"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
@@ -72,7 +73,7 @@ type JobSummary struct {
 	// Name of the pipeline
 	//
 	// required: false
-	// enum: build,build-deploy,promote,deploy
+	// enum: build,build-deploy,promote,deploy,apply-config
 	// example: build-deploy
 	Pipeline string `json:"pipeline"`
 
@@ -103,6 +104,13 @@ type JobSummary struct {
 	// Extensions:
 	// x-nullable: true
 	OverrideUseBuildCache *bool `json:"overrideUseBuildCache,omitempty"`
+
+	// DeployExternalDNS deploy external DNS
+	//
+	// required: false
+	// Extensions:
+	// x-nullable: true
+	DeployExternalDNS *bool `json:"deployExternalDNS,omitempty"`
 }
 
 // GetSummaryFromRadixJob Used to get job summary from a radix job
@@ -140,6 +148,8 @@ func GetSummaryFromRadixJob(job *radixv1.RadixJob) *JobSummary {
 		pipelineJob.PromotedFromEnvironment = job.Spec.Promote.FromEnvironment
 		pipelineJob.PromotedToEnvironment = job.Spec.Promote.ToEnvironment
 		pipelineJob.CommitID = job.Spec.Promote.CommitID
+	case radixv1.ApplyConfig:
+		pipelineJob.DeployExternalDNS = pointers.Ptr(job.Spec.ApplyConfig.DeployExternalDNS)
 	}
 
 	return pipelineJob

--- a/api/models/environment.go
+++ b/api/models/environment.go
@@ -32,6 +32,9 @@ func BuildEnvironment(rr *radixv1.RadixRegistration, ra *radixv1.RadixApplicatio
 	if activeRd, ok := slice.FindFirst(rdList, isActiveDeploymentForAppAndEnv(ra.Name, re.Spec.EnvName)); ok {
 		activeDeployment = BuildDeployment(rr, ra, &activeRd, deploymentList, podList, hpaList, secretList, eventList, rjList, certs, certRequests, tlsValidator, scaledObjects)
 		secrets = BuildSecrets(secretList, secretProviderClassList, &activeRd)
+		if len(activeDeployment.BuiltFromBranch) > 0 {
+			buildFromBranch = activeDeployment.BuiltFromBranch
+		}
 	}
 
 	return &environmentModels.Environment{

--- a/api/models/environment_summary.go
+++ b/api/models/environment_summary.go
@@ -25,19 +25,27 @@ func BuildEnvironmentSummaryList(rr *radixv1.RadixRegistration, ra *radixv1.Radi
 			re = &foundRe
 		}
 
+		deploymentSummary := getActiveDeploymentSummary(ra.GetName(), e.Name, rdList)
+		buildFromBranch := e.Build.From
 		env := &environmentModels.EnvironmentSummary{
 			Name:             e.Name,
-			BranchMapping:    e.Build.From,
-			ActiveDeployment: getActiveDeploymentSummary(ra.GetName(), e.Name, rdList),
+			BranchMapping:    buildFromBranch,
+			ActiveDeployment: deploymentSummary,
 			Status:           getEnvironmentConfigurationStatus(re).String(),
 		}
 		envList = append(envList, env)
 	}
 
 	for _, re := range slice.FindAll(reList, predicate.IsOrphanEnvironment) {
+		deploymentSummary := getActiveDeploymentSummary(ra.GetName(), re.Spec.EnvName, rdList)
+		buildFromBranch := ""
+		if deploymentSummary != nil {
+			buildFromBranch = deploymentSummary.BuiltFromBranch
+		}
 		env := &environmentModels.EnvironmentSummary{
 			Name:             re.Spec.EnvName,
-			ActiveDeployment: getActiveDeploymentSummary(ra.GetName(), re.Spec.EnvName, rdList),
+			BranchMapping:    buildFromBranch,
+			ActiveDeployment: deploymentSummary,
 			Status:           getEnvironmentConfigurationStatus(&re).String(),
 		}
 		envList = append(envList, env)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cert-manager/cert-manager v1.15.0
 	github.com/equinor/radix-common v1.9.5
 	github.com/equinor/radix-job-scheduler v1.11.0
-	github.com/equinor/radix-operator v1.64.0
+	github.com/equinor/radix-operator v1.65.1
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cert-manager/cert-manager v1.15.0
 	github.com/equinor/radix-common v1.9.5
 	github.com/equinor/radix-job-scheduler v1.11.0
-	github.com/equinor/radix-operator v1.65.1
+	github.com/equinor/radix-operator v1.66.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/equinor/radix-common v1.9.5 h1:p1xldkYUoavwIMguoxxOyVkOXLPA6K8qMsgzez
 github.com/equinor/radix-common v1.9.5/go.mod h1:+g0Wj0D40zz29DjNkYKVmCVeYy4OsFWKI7Qi9rA6kpY=
 github.com/equinor/radix-job-scheduler v1.11.0 h1:8wCmXOVl/1cto8q2WJQEE06Cw68/QmfoifYVR49vzkY=
 github.com/equinor/radix-job-scheduler v1.11.0/go.mod h1:yPXn3kDcMY0Z3kBkosjuefsdY1x2g0NlBeybMmHz5hc=
-github.com/equinor/radix-operator v1.64.0 h1:KbP0ZAX8zZSNzgejc7oOo087RkdrlTpBg4myk7zs48o=
-github.com/equinor/radix-operator v1.64.0/go.mod h1:uRW9SgVZ94hkpq87npVv2YVviRuXNJ1zgCleya1uvr8=
+github.com/equinor/radix-operator v1.65.1 h1:3lcjWEktQREFj4x1RYUUk9TrQvDQqIN3sJSv+XZEYtA=
+github.com/equinor/radix-operator v1.65.1/go.mod h1:bYXKrNGkeRL7ctqj4fwytRFsgHj4XR5ZRks7wXwqjXo=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/equinor/radix-common v1.9.5 h1:p1xldkYUoavwIMguoxxOyVkOXLPA6K8qMsgzez
 github.com/equinor/radix-common v1.9.5/go.mod h1:+g0Wj0D40zz29DjNkYKVmCVeYy4OsFWKI7Qi9rA6kpY=
 github.com/equinor/radix-job-scheduler v1.11.0 h1:8wCmXOVl/1cto8q2WJQEE06Cw68/QmfoifYVR49vzkY=
 github.com/equinor/radix-job-scheduler v1.11.0/go.mod h1:yPXn3kDcMY0Z3kBkosjuefsdY1x2g0NlBeybMmHz5hc=
-github.com/equinor/radix-operator v1.65.1 h1:3lcjWEktQREFj4x1RYUUk9TrQvDQqIN3sJSv+XZEYtA=
-github.com/equinor/radix-operator v1.65.1/go.mod h1:bYXKrNGkeRL7ctqj4fwytRFsgHj4XR5ZRks7wXwqjXo=
+github.com/equinor/radix-operator v1.66.0 h1:3gRM6mrmmaLMKnpF/hzfAFFuqeW8512XDlQRW1B0kXQ=
+github.com/equinor/radix-operator v1.66.0/go.mod h1:bYXKrNGkeRL7ctqj4fwytRFsgHj4XR5ZRks7wXwqjXo=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/swaggerui/html/swagger.json
+++ b/swaggerui/html/swagger.json
@@ -6269,6 +6269,12 @@
           "x-go-name": "ActiveTo",
           "example": "2006-01-02T15:04:05Z"
         },
+        "builtFromBranch": {
+          "description": "Name of the branch used to build the deployment",
+          "type": "string",
+          "x-go-name": "BuiltFromBranch",
+          "example": "main"
+        },
         "components": {
           "description": "Array of components",
           "type": "array",
@@ -6377,6 +6383,12 @@
           "x-go-name": "ActiveTo",
           "example": "2006-01-02T15:04:05Z"
         },
+        "builtFromBranch": {
+          "description": "Name of the branch used to build the deployment",
+          "type": "string",
+          "x-go-name": "BuiltFromBranch",
+          "example": "main"
+        },
         "commitID": {
           "description": "CommitID the commit ID of the branch to build",
           "type": "string",
@@ -6444,6 +6456,12 @@
     "DeploymentSummaryPipelineJobInfo": {
       "type": "object",
       "properties": {
+        "builtFromBranch": {
+          "description": "Name of the branch used to build the deployment",
+          "type": "string",
+          "x-go-name": "BuiltFromBranch",
+          "example": "main"
+        },
         "commitID": {
           "description": "CommitID the commit ID of the branch to build",
           "type": "string",
@@ -6947,6 +6965,12 @@
           "x-go-name": "Created",
           "example": "2006-01-02T15:04:05Z"
         },
+        "deployedToEnvironment": {
+          "description": "DeployedToEnvironment the name of the environment that was deployed to",
+          "type": "string",
+          "x-go-name": "DeployedToEnvironment",
+          "example": "qa"
+        },
         "deployments": {
           "description": "Array of deployments",
           "type": "array",
@@ -7302,6 +7326,12 @@
           "type": "string",
           "x-go-name": "PushImage",
           "example": "true"
+        },
+        "toEnvironment": {
+          "description": "Name of environment to build for",
+          "type": "string",
+          "x-go-name": "ToEnvironment",
+          "example": "prod"
         },
         "triggeredBy": {
           "description": "TriggeredBy of the job - if empty will use user token upn (user principle name)",

--- a/swaggerui/html/swagger.json
+++ b/swaggerui/html/swagger.json
@@ -6439,7 +6439,8 @@
             "build",
             "build-deploy",
             "promote",
-            "deploy"
+            "deploy",
+            "apply-config"
           ],
           "x-go-name": "PipelineJobType",
           "example": "build-deploy"
@@ -6480,7 +6481,8 @@
             "build",
             "build-deploy",
             "promote",
-            "deploy"
+            "deploy",
+            "apply-config"
           ],
           "x-go-name": "PipelineJobType",
           "example": "build-deploy"
@@ -6965,6 +6967,12 @@
           "x-go-name": "Created",
           "example": "2006-01-02T15:04:05Z"
         },
+        "deployExternalDNS": {
+          "description": "DeployExternalDNS deploy external DNS",
+          "type": "boolean",
+          "x-go-name": "DeployExternalDNS",
+          "x-nullable": true
+        },
         "deployedToEnvironment": {
           "description": "DeployedToEnvironment the name of the environment that was deployed to",
           "type": "string",
@@ -7000,6 +7008,12 @@
           "x-go-name": "Name",
           "example": "radix-pipeline-20181029135644-algpv-6hznh"
         },
+        "overrideUseBuildCache": {
+          "description": "OverrideUseBuildCache override default or configured build cache option",
+          "type": "boolean",
+          "x-go-name": "OverrideUseBuildCache",
+          "x-nullable": true
+        },
         "pipeline": {
           "description": "Name of the pipeline",
           "type": "string",
@@ -7007,7 +7021,8 @@
             "build",
             "build-deploy",
             "promote",
-            "deploy"
+            "deploy",
+            "apply-config"
           ],
           "x-go-name": "Pipeline",
           "example": "build-deploy"
@@ -7102,6 +7117,12 @@
           "x-go-name": "Created",
           "example": "2006-01-02T15:04:05Z"
         },
+        "deployExternalDNS": {
+          "description": "DeployExternalDNS deploy external DNS",
+          "type": "boolean",
+          "x-go-name": "DeployExternalDNS",
+          "x-nullable": true
+        },
         "ended": {
           "description": "Ended timestamp",
           "type": "string",
@@ -7148,7 +7169,8 @@
             "build",
             "build-deploy",
             "promote",
-            "deploy"
+            "deploy",
+            "apply-config"
           ],
           "x-go-name": "Pipeline",
           "example": "build-deploy"
@@ -7272,6 +7294,12 @@
       "description": "PipelineParametersApplyConfig describes base info",
       "type": "object",
       "properties": {
+        "deployExternalDNS": {
+          "description": "DeployExternalDNS deploy external DNS",
+          "type": "boolean",
+          "x-go-name": "DeployExternalDNS",
+          "x-nullable": true
+        },
         "triggeredBy": {
           "description": "TriggeredBy of the job - if empty will use user token upn (user principle name)",
           "type": "string",
@@ -7296,6 +7324,12 @@
           "type": "string",
           "x-go-name": "CommitID",
           "example": "4faca8595c5283a9d0f17a623b9255a0d9866a2e"
+        },
+        "deployExternalDNS": {
+          "description": "DeployExternalDNS deploy external DNS",
+          "type": "boolean",
+          "x-go-name": "DeployExternalDNS",
+          "x-nullable": true
         },
         "imageName": {
           "description": "ImageName of the component, without repository name and image-tag",


### PR DESCRIPTION
* Get component env-vars from kube deployment instead of operator code

* Fixed unit-tests

* Filtered away secrets