### PR TITLE
Use Service Account to fetch event

### DIFF
--- a/api/environments/environment_handler.go
+++ b/api/environments/environment_handler.go
@@ -38,7 +38,7 @@ type EnvironmentHandlerOptions func(*EnvironmentHandler)
 func WithAccounts(accounts models.Accounts) EnvironmentHandlerOptions {
 	return func(eh *EnvironmentHandler) {
 		eh.deployHandler = deployments.Init(accounts)
-		eh.eventHandler = events.Init(accounts.UserAccount.Client, accounts.UserAccount.RadixClient)
+		eh.eventHandler = events.Init(accounts)
 		eh.accounts = accounts
 	}
 }


### PR DESCRIPTION
A regular user does not have access to read RadixEnvironment crds, so the fetch events failed.

 I have updated the related code to use the ServiceAccount credentials instead for fetching the events