### PR TITLE
feat: improve log streaming when behind nginx

### DIFF
--- a/models/controller.go
+++ b/models/controller.go
@@ -121,6 +121,8 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 	}
 
 	m.Lock()
+	defer m.Unlock() // good practice
+
 	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
 		log.Ctx(r.Context()).Err(err).Msg("failed to read stream")
 		fmt.Fprintf(w, "event: error\n\n")

--- a/models/controller.go
+++ b/models/controller.go
@@ -95,7 +95,7 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 	tickerCtx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 	go func() {
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(15 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {

--- a/models/controller.go
+++ b/models/controller.go
@@ -124,12 +124,10 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
 		log.Ctx(r.Context()).Err(err).Msg("failed to read stream")
 		fmt.Fprintf(w, "event: error\n\n")
-		flusher.Flush()
 		return
 	}
 
 	fmt.Fprintf(w, "event: completed\n\n")
-	flusher.Flush()
 }
 
 // ByteArrayResponse Used for response data. I.e. image

--- a/models/controller.go
+++ b/models/controller.go
@@ -87,8 +87,6 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 	w.WriteHeader(http.StatusOK)
 	m := sync.Mutex{}
 
-	log.Ctx(r.Context()).Debug().Msg("starting event stream response")
-
 	// Make sure we send an initial message to the client
 	fmt.Fprintf(w, "event: started\n\n") // sends an event comment
 	flusher.Flush()
@@ -103,7 +101,6 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 			select {
 			case <-ticker.C:
 				m.Lock()
-				log.Ctx(r.Context()).Debug().Msg("sending healthcheck")
 				fmt.Fprintf(w, ": healthcheck\n\n") // sends an event comment
 				flusher.Flush()
 				m.Unlock()
@@ -117,7 +114,6 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Text()
-		log.Ctx(r.Context()).Debug().Msgf("sending line: %s", line)
 		m.Lock()
 		fmt.Fprintf(w, "data: %s\n\n", line)
 		flusher.Flush()
@@ -132,7 +128,6 @@ func (c *DefaultController) ReaderEventStreamResponse(w http.ResponseWriter, r *
 		return
 	}
 
-	log.Ctx(r.Context()).Debug().Msg("closing event stream")
 	fmt.Fprintf(w, "event: completed\n\n")
 	flusher.Flush()
 }


### PR DESCRIPTION
2 important bits:
- Avoid writing at the same time
- send the magic `X-Accel-Buffering` header to avoid Nginx buffering the response (alternatively upgrade radix-operator to support changing the `proxy_buffering` property)

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering

Added a few events to the stream to make it easier to troubleshoot