### PR TITLE
feat: expose config api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,32 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Run locally",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${workspaceFolder}/main.go",
-            "env": {
-                "RADIX_CONTAINER_REGISTRY":"radixdev.azurecr.io",
-                "RADIX_DNS_ZONE":  "dev.radix.equinor.com",
-                "RADIX_ENVIRONMENT":"qa",
-                "PROMETHEUS_URL":"http://localhost:9091",
-                "RADIX_APP":"radix-api",
-                "LOG_LEVEL":"info",
-                "LOG_PRETTY":"true",
-                "OIDC_AZURE_ISSUER": "https://sts.windows.net/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/",
-                "OIDC_AZURE_AUDIENCE": "6dae42f8-4368-4678-94ff-3960e28e3630",
-                "OIDC_KUBERNETES_ISSUER": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/79c72762-ce8d-4874-90cd-a119a5050503/",
-                "OIDC_KUBERNETES_AUDIENCE": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/79c72762-ce8d-4874-90cd-a119a5050503/"
-            }
-        }
-    ]
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run locally",
+			"type": "go",
+			"request": "launch",
+			"mode": "auto",
+			"program": "${workspaceFolder}/main.go",
+			"env": {
+				"RADIX_CONTAINER_REGISTRY": "radixdev.azurecr.io",
+				"RADIX_DNS_ZONE": "dev.radix.equinor.com",
+				"RADIX_ENVIRONMENT": "qa",
+				"PROMETHEUS_URL": "http://localhost:9091",
+				"RADIX_APP": "radix-api",
+				"LOG_LEVEL": "info",
+				"LOG_PRETTY": "true",
+				"OIDC_AZURE_ISSUER": "https://sts.windows.net/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/",
+				"OIDC_AZURE_AUDIENCE": "6dae42f8-4368-4678-94ff-3960e28e3630",
+				"OIDC_KUBERNETES_ISSUER": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/79c72762-ce8d-4874-90cd-a119a5050503/",
+				"OIDC_KUBERNETES_AUDIENCE": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/79c72762-ce8d-4874-90cd-a119a5050503/",
+				"RADIX_CLUSTER_NAME": "weekly-40",
+				"RADIX_CLUSTER_TYPE": "development",
+				"RADIX_CLUSTER_EGRESS_IPS": "192.168.84.0/30,10.0.0.0/30",
+				"RADIX_CLUSTER_OIDC_ISSUERS": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/79c72762-ce8d-4874-90cd-a119a5050503/,https://test-issuer.internal.radix.equinor.com"
+			}
+		}
+	]
 }

--- a/api/configuration/configuration_controller.go
+++ b/api/configuration/configuration_controller.go
@@ -1,0 +1,58 @@
+package configuration
+
+import (
+	"net/http"
+
+	"github.com/equinor/radix-api/models"
+)
+
+const rootPath = "/configuration"
+
+type configurationController struct {
+	*models.DefaultController
+
+	handler ConfigurationHandler
+}
+
+// NewConfigurationController Constructor
+func NewConfigurationController(handler ConfigurationHandler) models.Controller {
+	return &configurationController{
+		handler: handler,
+	}
+}
+
+// GetRoutes List the supported routes of this handler
+func (c *configurationController) GetRoutes() models.Routes {
+	routes := models.Routes{
+		models.Route{
+			Path:                      rootPath + "/settings",
+			Method:                    "GET",
+			HandlerFunc:               c.GetSettings,
+			AllowUnauthenticatedUsers: true,
+		},
+	}
+
+	return routes
+}
+
+// GetSettings reveals the settings for the selected cluster environment
+func (c *configurationController) GetSettings(accounts models.Accounts, w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /configuration/settings settings getConfigurationSettings
+	// ---
+	// summary: Show the cluster environment settings
+	// responses:
+	//   "200":
+	//     description: "Successful operation"
+	//     schema:
+	//        "$ref": "#/definitions/ConfigurationSettings"
+	//   "500":
+	//     description: "Internal Server Error"
+
+	s, err := c.handler.GetSettings(r.Context())
+	if err != nil {
+		c.ErrorResponse(w, r, err)
+		return
+	}
+
+	c.JSONResponse(w, r, s)
+}

--- a/api/configuration/configuration_controller.go
+++ b/api/configuration/configuration_controller.go
@@ -28,7 +28,7 @@ func (c *configurationController) GetRoutes() models.Routes {
 			Path:                      rootPath + "/settings",
 			Method:                    "GET",
 			HandlerFunc:               c.GetSettings,
-			AllowUnauthenticatedUsers: true,
+			AllowUnauthenticatedUsers: false,
 		},
 	}
 

--- a/api/configuration/configuration_handler.go
+++ b/api/configuration/configuration_handler.go
@@ -1,0 +1,34 @@
+package configuration
+
+import (
+	"context"
+
+	configurationModels "github.com/equinor/radix-api/api/configuration/models"
+	"github.com/equinor/radix-api/models"
+)
+
+type configurationHandler struct {
+	accounts models.Accounts
+}
+
+type ConfigurationHandler interface {
+	// Init Constructor
+	GetSettings(ctx context.Context) (configurationModels.Settings, error)
+}
+
+// Init Constructor
+func Init(accounts models.Accounts) ConfigurationHandler {
+	return &configurationHandler{
+		accounts: accounts,
+	}
+}
+
+func (h *configurationHandler) GetSettings(ctx context.Context) (configurationModels.Settings, error) {
+	return configurationModels.Settings{
+		ClusterEgressIps:   []string{"104.45.84.0/30"},
+		ClusterOidcIssuers: []string{"https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0"},
+		ClusterBaseDomain:  "dev.radix.equinor.com",
+		ClusterType:        "development",
+		ClusterName:        "weekly-40",
+	}, nil
+}

--- a/api/configuration/configuration_handler.go
+++ b/api/configuration/configuration_handler.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	configurationModels "github.com/equinor/radix-api/api/configuration/models"
-	"github.com/equinor/radix-api/models"
+	"github.com/equinor/radix-api/internal/config"
 )
 
 type configurationHandler struct {
-	accounts models.Accounts
+	config config.Config
 }
 
 type ConfigurationHandler interface {
@@ -17,18 +17,18 @@ type ConfigurationHandler interface {
 }
 
 // Init Constructor
-func Init(accounts models.Accounts) ConfigurationHandler {
+func Init(config config.Config) ConfigurationHandler {
 	return &configurationHandler{
-		accounts: accounts,
+		config: config,
 	}
 }
 
 func (h *configurationHandler) GetSettings(ctx context.Context) (configurationModels.Settings, error) {
 	return configurationModels.Settings{
-		ClusterEgressIps:   []string{"104.45.84.0/30"},
-		ClusterOidcIssuers: []string{"https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0"},
-		ClusterBaseDomain:  "dev.radix.equinor.com",
-		ClusterType:        "development",
-		ClusterName:        "weekly-40",
+		ClusterEgressIps:   h.config.ClusterEgressIps,
+		ClusterOidcIssuers: h.config.ClusterOidcIssuers,
+		DNSZone:            h.config.DNSZone,
+		ClusterType:        h.config.ClusterType,
+		ClusterName:        h.config.ClusterName,
 	}, nil
 }

--- a/api/configuration/models/configuration.go
+++ b/api/configuration/models/configuration.go
@@ -1,0 +1,11 @@
+package models
+
+// Environment holds detail information about environment
+// swagger:model ConfigurationSettings
+type Settings struct {
+	ClusterEgressIps   []string `json:"clusterEgressIps"`
+	ClusterOidcIssuers []string `json:"clusterOidcIssuers"`
+	ClusterBaseDomain  string   `json:"clusterBaseDomain"`
+	ClusterType        string   `json:"clusterType"`
+	ClusterName        string   `json:"clusterName"`
+}

--- a/api/configuration/models/configuration.go
+++ b/api/configuration/models/configuration.go
@@ -3,9 +3,25 @@ package models
 // Environment holds detail information about environment
 // swagger:model ConfigurationSettings
 type Settings struct {
-	ClusterEgressIps   []string `json:"clusterEgressIps"`
+	// ClusterEgressIps List of egress IPs for the cluster. Can be used for whitelisting in external services.
+	ClusterEgressIps []string `json:"clusterEgressIps"`
+
+	// ClusterOidcIssuers List of OIDC issuers for the cluster. Can be used for configuring OIDC clients and setting up Federated Credentials.
 	ClusterOidcIssuers []string `json:"clusterOidcIssuers"`
-	ClusterBaseDomain  string   `json:"clusterBaseDomain"`
-	ClusterType        string   `json:"clusterType"`
-	ClusterName        string   `json:"clusterName"`
+
+	// DNSZone The DNS zone configured for the cluster environment
+	//
+	// example: qa.radix.equinor.com
+	DNSZone string `json:"dnsZone"`
+
+	// ClusterType The type of the cluster
+	//
+	// example: production
+
+	ClusterType string `json:"clusterType"`
+
+	// ClusterName The name of the cluster
+	//
+	// example: weekly-40
+	ClusterName string `json:"clusterName"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,19 +8,24 @@ import (
 )
 
 type Config struct {
-	Port               int    `envconfig:"PORT" default:"3002" desc:"Port where API will be served"`
-	MetricsPort        int    `envconfig:"METRICS_PORT" default:"9090"  desc:"Port where Metrics will be served"`
-	ProfilePort        int    `envconfig:"PROFILE_PORT" default:"7070"  desc:"Port where Profiler will be served"`
-	UseProfiler        bool   `envconfig:"USE_PROFILER" default:"false" desc:"Enable Profiler"`
-	LogLevel           string `envconfig:"LOG_LEVEL" default:"info"`
-	LogPrettyPrint     bool   `envconfig:"LOG_PRETTY" default:"false"`
+	Port           int    `envconfig:"PORT" default:"3002" desc:"Port where API will be served"`
+	MetricsPort    int    `envconfig:"METRICS_PORT" default:"9090"  desc:"Port where Metrics will be served"`
+	ProfilePort    int    `envconfig:"PROFILE_PORT" default:"7070"  desc:"Port where Profiler will be served"`
+	UseProfiler    bool   `envconfig:"USE_PROFILER" default:"false" desc:"Enable Profiler"`
+	LogLevel       string `envconfig:"LOG_LEVEL" default:"info"`
+	LogPrettyPrint bool   `envconfig:"LOG_PRETTY" default:"false"`
 
-	AppName         string `envconfig:"RADIX_APP" required:"true" desc:"Should be radix-api"`
-	EnvironmentName string `envconfig:"RADIX_ENVIRONMENT" required:"true" desc:"Should be qa or prod"`
-	DNSZone         string `envconfig:"RADIX_DNS_ZONE" required:"true" desc:"should be <env>.radix.equinor.com"`
-	AzureOidc       Oidc   `envconfig:"OIDC_AZURE" required:"true"`
-	KubernetesOidc  Oidc   `envconfig:"OIDC_KUBERNETES" required:"true"`
-	PrometheusUrl   string `envconfig:"PROMETHEUS_URL" required:"true"`
+	AppName            string   `envconfig:"RADIX_APP" required:"true" desc:"Should be radix-api"`
+	EnvironmentName    string   `envconfig:"RADIX_ENVIRONMENT" required:"true" desc:"Should be qa or prod"`
+	DNSZone            string   `envconfig:"RADIX_DNS_ZONE" required:"true" desc:"should be <env>.radix.equinor.com"`
+	ClusterName        string   `envconfig:"RADIX_CLUSTER_NAME" required:"true" desc:"Name of the cluster, e.g. weekly-40"`
+	ClusterType        string   `envconfig:"RADIX_CLUSTER_TYPE" required:"true" desc:"Type of the cluster, e.g. development, test, production"`
+	ClusterEgressIps   []string `envconfig:"RADIX_CLUSTER_EGRESS_IPS" required:"true" desc:"Comma separated list of Egress IPs of the cluster, e.g. 192.168.84.0/30,10.0.0.0/30"`
+	ClusterOidcIssuers []string `envconfig:"RADIX_CLUSTER_OIDC_ISSUERS" required:"true" desc:"Comma separated list of OIDC issuers of the cluster, e.g. https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0,http://localhost:5000"`
+
+	AzureOidc      Oidc   `envconfig:"OIDC_AZURE" required:"true"`
+	KubernetesOidc Oidc   `envconfig:"OIDC_KUBERNETES" required:"true"`
+	PrometheusUrl  string `envconfig:"PROMETHEUS_URL" required:"true"`
 }
 
 type Oidc struct {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/equinor/radix-api/api/buildsecrets"
 	"github.com/equinor/radix-api/api/buildstatus"
 	buildModels "github.com/equinor/radix-api/api/buildstatus/models"
+	"github.com/equinor/radix-api/api/configuration"
 	"github.com/equinor/radix-api/api/deployments"
 	"github.com/equinor/radix-api/api/environments"
 	"github.com/equinor/radix-api/api/environmentvariables"
@@ -173,5 +174,6 @@ func getControllers(config config.Config) ([]models.Controller, error) {
 		buildstatus.NewBuildStatusController(buildStatus),
 		alerting.NewAlertingController(),
 		secrets.NewSecretController(tlsvalidation.DefaultValidator()),
+		configuration.NewConfigurationController(),
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 func main() {
 	c := config.MustParse()
 	setupLogger(c.LogLevel, c.LogPrettyPrint)
+	log.Info().Any("config", c).Msgf("Starting radix-api %s in %s environment", c.AppName, c.EnvironmentName)
 
 	servers := []*http.Server{
 		initializeServer(c),
@@ -174,6 +175,6 @@ func getControllers(config config.Config) ([]models.Controller, error) {
 		buildstatus.NewBuildStatusController(buildStatus),
 		alerting.NewAlertingController(),
 		secrets.NewSecretController(tlsvalidation.DefaultValidator()),
-		configuration.NewConfigurationController(),
+		configuration.NewConfigurationController(configuration.Init(config)),
 	}, nil
 }

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -37,6 +37,10 @@ spec:
         OIDC_AZURE_ISSUER: https://sts.windows.net/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/
         OIDC_KUBERNETES_ISSUER: ""
         OIDC_KUBERNETES_AUDIENCE: ""
+        RADIX_CLUSTER_NAME: ""
+        RADIX_CLUSTER_TYPE: ""
+        RADIX_CLUSTER_EGRESS_IPS: ""
+        RADIX_CLUSTER_OIDC_ISSUERS: ""
       environmentConfig:
         - environment: qa
           horizontalScaling:

--- a/swaggerui/html/swagger.json
+++ b/swaggerui/html/swagger.json
@@ -6664,11 +6664,8 @@
       "description": "Environment holds detail information about environment",
       "type": "object",
       "properties": {
-        "clusterBaseDomain": {
-          "type": "string",
-          "x-go-name": "ClusterBaseDomain"
-        },
         "clusterEgressIps": {
+          "description": "ClusterEgressIps List of egress IPs for the cluster. Can be used for whitelisting in external services.",
           "type": "array",
           "items": {
             "type": "string"
@@ -6676,10 +6673,13 @@
           "x-go-name": "ClusterEgressIps"
         },
         "clusterName": {
+          "description": "ClusterName The name of the cluster",
           "type": "string",
-          "x-go-name": "ClusterName"
+          "x-go-name": "ClusterName",
+          "example": "weekly-40"
         },
         "clusterOidcIssuers": {
+          "description": "ClusterOidcIssuers List of OIDC issuers for the cluster. Can be used for configuring OIDC clients and setting up Federated Credentials.",
           "type": "array",
           "items": {
             "type": "string"
@@ -6689,6 +6689,12 @@
         "clusterType": {
           "type": "string",
           "x-go-name": "ClusterType"
+        },
+        "dnsZone": {
+          "description": "DNSZone The DNS zone configured for the cluster environment",
+          "type": "string",
+          "x-go-name": "DNSZone",
+          "example": "qa.radix.equinor.com"
         }
       },
       "x-go-name": "Settings",

--- a/swaggerui/html/swagger.json
+++ b/swaggerui/html/swagger.json
@@ -5780,6 +5780,26 @@
           }
         }
       }
+    },
+    "/configuration/settings": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Show the cluster environment settings",
+        "operationId": "getConfigurationSettings",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationSettings"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -6639,6 +6659,40 @@
         }
       },
       "x-go-package": "github.com/equinor/radix-api/api/applications/models"
+    },
+    "ConfigurationSettings": {
+      "description": "Environment holds detail information about environment",
+      "type": "object",
+      "properties": {
+        "clusterBaseDomain": {
+          "type": "string",
+          "x-go-name": "ClusterBaseDomain"
+        },
+        "clusterEgressIps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "ClusterEgressIps"
+        },
+        "clusterName": {
+          "type": "string",
+          "x-go-name": "ClusterName"
+        },
+        "clusterOidcIssuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "ClusterOidcIssuers"
+        },
+        "clusterType": {
+          "type": "string",
+          "x-go-name": "ClusterType"
+        }
+      },
+      "x-go-name": "Settings",
+      "x-go-package": "github.com/equinor/radix-api/api/configuration/models"
     },
     "DNSAlias": {
       "description": "DNSAlias holds public DNS alias information",


### PR DESCRIPTION
To test:

```shell
ACCESS_TOKEN=$(az account get-access-token --resource 6dae42f8-4368-4678-94ff-3960e28e3630 --query accessToken --output tsv)
curl 'http://localhost:3002/api/v1/configuration/settings' -H "Authorization: Bearer ${ACCESS_TOKEN}" |jq
```

```json
{
  "clusterEgressIps": [
    "192.168.84.0/30",
    "10.0.0.0/30"
  ],
  "clusterOidcIssuers": [
    "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/79c72762-ce8d-4874-90cd-a119a5050503/",
    "https://test-issuer.internal.radix.equinor.com"
  ],
  "dnsZone": "dev.radix.equinor.com",
  "clusterType": "development",
  "clusterName": "weekly-40"
}
```