### PR TITLE
fix: do not fail if reading RadixApplication before its created

### DIFF
--- a/api/applications/applications_controller_test.go
+++ b/api/applications/applications_controller_test.go
@@ -998,7 +998,7 @@ func TestHandleTriggerPipeline_ForNonMappedAndMappedAndMagicBranchEnvironment_Jo
 
 func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedForExisting(t *testing.T) {
 	// Setup
-	commonTestUtils, controllerTestUtils, _, _, _, _, _, _, _ := setupTest(t)
+	_, controllerTestUtils, _, _, _, _, _, _, _ := setupTest(t)
 
 	registerAppParam := buildApplicationRegistrationRequest(
 		anApplicationRegistration().
@@ -1009,12 +1009,6 @@ func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedFor
 	)
 	responseChannel := controllerTestUtils.ExecuteRequestWithParameters("POST", "/api/v1/applications", registerAppParam)
 	<-responseChannel
-
-	// Create RadixApplication
-	_, err := commonTestUtils.ApplyApplication(builders.ARadixApplication().
-		WithAppName("any-app").
-		WithEnvironment("dev", "maincfg"))
-	require.NoError(t, err)
 
 	// Test
 	const pushCommitID = "4faca8595c5283a9d0f17a623b9255a0d9866a2e"
@@ -1042,7 +1036,7 @@ func TestHandleTriggerPipeline_ExistingAndNonExistingApplication_JobIsCreatedFor
 	assert.Equal(t, http.StatusOK, response.Code)
 
 	jobSummary := jobModels.JobSummary{}
-	err = controllertest.GetResponseBody(response, &jobSummary)
+	err := controllertest.GetResponseBody(response, &jobSummary)
 	require.NoError(t, err)
 	assert.Equal(t, "any-app", jobSummary.AppName)
 	assert.Equal(t, "maincfg", jobSummary.GitRef)

--- a/api/applications/get_applications_handler.go
+++ b/api/applications/get_applications_handler.go
@@ -238,7 +238,7 @@ func getLatestJobPerApplication(ctx context.Context, radixClient versioned.Inter
 				ra, err := radixClient.RadixV1().RadixApplications(crdUtils.GetAppNamespace(rr.GetName())).Get(ctx, rr.GetName(), metav1.GetOptions{})
 				if err != nil {
 					// Log error but continue - ResolveUseBuildKit will use default when ra is nil
-					log.Ctx(ctx).Warn().Err(err).Msgf("Failed to get RadixApplication %s for UseBuildKit determination", rr.GetName())
+					log.Ctx(ctx).Warn().Err(err).Str("radixapplication", rr.GetName()).Msg("Failed to get RadixApplication")
 					ra = nil
 				}
 				jobSummaries.Store(rr.GetName(), jobModels.GetSummaryFromRadixJob(ra, latestJob))

--- a/api/applications/start_job_handler.go
+++ b/api/applications/start_job_handler.go
@@ -40,7 +40,8 @@ func createPipelineJob(ctx context.Context, radixClient versioned.Interface, app
 	}
 	ra, err := radixClient.RadixV1().RadixApplications(appNamespace).Get(ctx, appName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		log.Ctx(ctx).Warn().Err(err).Str("radixapplication", appName).Msg("Failed to get RadixApplication")
+		ra = nil
 	}
 
 	log.Ctx(ctx).Info().Msgf("Started jobController: %s, %s", job.GetName(), jobController.WorkerImage)

--- a/api/jobs/job_handler.go
+++ b/api/jobs/job_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	crdUtils "github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/rs/zerolog/log"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -373,7 +374,8 @@ func (jh JobHandler) getJobFromRadixJob(ctx context.Context, job *v1.RadixJob, j
 		// Fetch RadixApplication to accurately determine UseBuildKit
 		ra, err := jh.userAccount.RadixClient.RadixV1().RadixApplications(crdUtils.GetAppNamespace(appName)).Get(ctx, appName, metav1.GetOptions{})
 		if err != nil {
-			return nil, err
+			log.Ctx(ctx).Error().Err(err).Str("radixapplication", appName).Msg("Unable to fetch RadixApplication")
+			ra = nil
 		}
 		jobModel.UseBuildKit = jobModels.IsUsingBuildKit(ra)
 		jobModel.UseBuildCache = job.Spec.Build.UseBuildCache

--- a/api/jobs/job_handler_test.go
+++ b/api/jobs/job_handler_test.go
@@ -13,7 +13,6 @@ import (
 	radixutils "github.com/equinor/radix-common/utils"
 	"github.com/equinor/radix-common/utils/pointers"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
-	commontest "github.com/equinor/radix-operator/pkg/apis/test"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/apis/utils/slice"
 	radixfake "github.com/equinor/radix-operator/pkg/client/clientset/versioned/fake"
@@ -98,12 +97,6 @@ func (s *JobHandlerTestSuite) Test_GetApplicationJob() {
 	step1Name, step1Pod, step1Condition, step1Started, step1Ended, step1Components := "step1_name", "step1_pod", radixv1.JobRunning, metav1.Now(), metav1.NewTime(time.Now().Add(1*time.Hour)), []string{"step1_comp1", "step1_comp2"}
 	step2Name := "step2_name"
 
-	// Create RadixApplication
-	commontest.CreateAppNamespace(s.kubeClient, appName)
-	ra := utils.ARadixApplication().WithAppName(appName).BuildRA()
-	_, err := s.radixClient.RadixV1().RadixApplications(utils.GetAppNamespace(appName)).Create(context.Background(), ra, metav1.CreateOptions{})
-	s.NoError(err)
-
 	rj := &radixv1.RadixJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -129,7 +122,7 @@ func (s *JobHandlerTestSuite) Test_GetApplicationJob() {
 			},
 		},
 	}
-	_, err = s.radixClient.RadixV1().RadixJobs(rj.Namespace).Create(context.Background(), rj, metav1.CreateOptions{})
+	_, err := s.radixClient.RadixV1().RadixJobs(rj.Namespace).Create(context.Background(), rj, metav1.CreateOptions{})
 	s.NoError(err)
 
 	deploymentName := "a_deployment"
@@ -296,12 +289,6 @@ func (s *JobHandlerTestSuite) TestJobHandler_RerunJob() {
 			dh := deployMock.NewMockDeployHandler(ctrl)
 			jh := s.getJobHandler(dh)
 
-			// Create RadixApplication
-			commontest.CreateAppNamespace(s.kubeClient, appName)
-			ra := utils.ARadixApplication().WithAppName(appName).BuildRA()
-			_, err := s.radixClient.RadixV1().RadixApplications(namespace).Create(context.Background(), ra, metav1.CreateOptions{})
-			s.NoError(err)
-
 			if tt.existingJob != nil {
 				_, err := s.accounts.UserAccount.RadixClient.RadixV1().RadixJobs(namespace).Create(context.Background(), &radixv1.RadixJob{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: tt.existingJob.name},
@@ -311,7 +298,7 @@ func (s *JobHandlerTestSuite) TestJobHandler_RerunJob() {
 				s.NoError(err)
 			}
 
-			err = jh.RerunJob(context.Background(), appName, tt.jobNameToRerun)
+			err := jh.RerunJob(context.Background(), appName, tt.jobNameToRerun)
 			s.Equal(tt.expectedError, err)
 		})
 	}

--- a/api/jobs/manage_job_handler.go
+++ b/api/jobs/manage_job_handler.go
@@ -75,7 +75,8 @@ func (jh JobHandler) createPipelineJob(ctx context.Context, appName string, job 
 
 	ra, err := jh.userAccount.RadixClient.RadixV1().RadixApplications(appNamespace).Get(ctx, appName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		log.Ctx(ctx).Warn().Err(err).Str("radixapplication", appName).Msg("Failed to get RadixApplication")
+		ra = nil
 	}
 
 	log.Ctx(ctx).Info().Msgf("Started job: %s, %s", job.GetName(), WorkerImage)


### PR DESCRIPTION
In some cases we read RadixApplication before its created (to determine wether BuildKit is probably used or not)

We will move buildkit status to RadixJob status very soon, and remove the dependency for RadixApplication at the same time (for these code blocks)